### PR TITLE
feat(unplugin-typia): Replace `verbose` with `log`

### DIFF
--- a/examples/sveltekit/vite.config.ts
+++ b/examples/sveltekit/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   clearScreen: false,
   plugins: [
     UnpluginTypia({
-      verbose: true,
+      log: "verbose",
       cache: {
         enable: true,
       }

--- a/packages/unplugin-typia/src/core/index.ts
+++ b/packages/unplugin-typia/src/core/index.ts
@@ -32,14 +32,16 @@ const unpluginFactory: UnpluginFactory<
 	const options = resolveOptions(rawOptions);
 	const filter = createFilter(options.include, options.exclude);
 
-	const { cache: cacheOptions, verbose } = options;
+	const { cache: cacheOptions, log } = options;
 
-	const showLog = verbose && cacheOptions.enable;
-
-	consola.box(
+	if (log) {
+		consola.box(
 		`[unplugin-typia]`,
 		cacheOptions.enable ? `Cache enabled` : `Cache disabled`,
-	);
+		);
+	}
+
+	const showLog = log === 'verbose' && cacheOptions.enable;
 
 	return {
 		name,

--- a/packages/unplugin-typia/src/core/options.ts
+++ b/packages/unplugin-typia/src/core/options.ts
@@ -58,10 +58,10 @@ export interface Options {
 	cache?: CacheOptions;
 
 	/**
-	 * Log verbose information.
-	 * @default false
+	 * Enable debug mode.
+	 * @default true
 	 */
-	verbose?: boolean;
+	log?: boolean | 'verbose';
 }
 
 /**
@@ -89,7 +89,7 @@ export function resolveOptions(options: Options): OptionsResolved {
 		enforce: 'enforce' in options ? options.enforce : 'pre',
 		cwd: options.cwd ?? process.cwd(),
 		typia: options.typia ?? {},
-		verbose: options.verbose ?? false,
+		log: options?.log ?? true,
 		cache: resolvedCacheOptions(options.cache),
 	};
 }


### PR DESCRIPTION
The verbose option in unplugin-typia has been replaced with a log option. This new option can be set to either a boolean value or 'verbose'. This change provides more control over the logging behavior of the plugin and aligns with common logging practices.