### PR TITLE
feat(ci): Add publish dry-run step to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,11 +40,24 @@ jobs:
       - run: bun i --frozen-lockfile
       - run: bun run lint
 
+  publish-dry-run:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - run: bun i --frozen-lockfile
+      - run: bun run publish --dry-run
+        working-directory: packages/unplugin-typia
+
   action-timeline:
     needs:
       - lint
       - test
       - build-examples
+      - publish-dry-run
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This commit introduces a new step in the CI workflow that performs a dry-run of the package publishing process. This step is crucial for ensuring that the package is ready for publishing and will not encounter any issues during the actual publish process.