### PR TITLE
feat(README): update examples list

### DIFF
--- a/packages/unplugin-typia/README.md
+++ b/packages/unplugin-typia/README.md
@@ -58,22 +58,6 @@ Examples:
 <br></details>
 
 <details>
-<summary>Rollup</summary><br>
-
-```ts
-// rollup.config.js
-import UnpluginTypia from '@ryoppippi/unplugin-typia/rollup';
-
-export default {
-	plugins: [
-		UnpluginTypia({ /* options */ }),
-	],
-};
-```
-
-<br></details>
-
-<details>
 <summary>esbuild</summary><br>
 
 ```ts
@@ -90,22 +74,6 @@ export default {
 
 Examples:
 - [`examples/esbuild`](https://github.com/ryoppippi/unplugin-typia/tree/main/examples/esbuild)
-
-<br></details>
-
-<details>
-<summary>Webpack</summary><br>
-
-```ts
-// webpack.config.js
-const UnpluginTypia = require('@ryoppippi/unplugin-typia/webpack');
-
-module.exports = {
-	plugins: [
-		UnpluginTypia({ /* options */ }),
-	],
-};
-```
 
 <br></details>
 
@@ -127,9 +95,39 @@ Examples:
 
 <br></details>
 
-More integration guides can be found in the [`JSR Doc`](https://jsr.io/@ryoppippi/unplugin-typia/doc)
+<details>
+<summary>Rollup</summary><br>
 
-## Examples
+```ts
+// rollup.config.js
+import UnpluginTypia from '@ryoppippi/unplugin-typia/rollup';
+
+export default {
+	plugins: [
+		UnpluginTypia({ /* options */ }),
+	],
+};
+```
+
+<br></details>
+
+<details>
+<summary>Webpack</summary><br>
+
+```ts
+// webpack.config.js
+const UnpluginTypia = require('@ryoppippi/unplugin-typia/webpack');
+
+module.exports = {
+	plugins: [
+		UnpluginTypia({ /* options */ }),
+	],
+};
+```
+
+<br></details>
+
+More integration guides can be found in the [`JSR Doc`](https://jsr.io/@ryoppippi/unplugin-typia/doc)
 
 You can find examples in the [`examples/`](https://github.com/ryoppippi/unplugin-typia/tree/main/examples).
 

--- a/packages/unplugin-typia/README.md
+++ b/packages/unplugin-typia/README.md
@@ -49,7 +49,11 @@ export default defineConfig({
 });
 ```
 
-Example: [`playground/`](./playground/)
+Examples: 
+- [`examples/vite-vanilla`](https://github.com/ryoppippi/unplugin-typia/tree/main/examples/vite-vanilla)
+- [`examples/vite-react`](https://github.com/ryoppippi/unplugin-typia/tree/main/examples/vite-react)
+- [`examples/vite-hono`](https://github.com/ryoppippi/unplugin-typia/tree/main/examples/vite-hono)
+- [`examples/sveltekit`](https://github.com/ryoppippi/unplugin-typia/tree/main/examples/sveltekit)
 
 <br></details>
 
@@ -84,6 +88,9 @@ export default {
 };
 ```
 
+Examples:
+- [`examples/esbuild`](https://github.com/ryoppippi/unplugin-typia/tree/main/examples/esbuild)
+
 <br></details>
 
 <details>
@@ -114,6 +121,9 @@ const config = {};
 
 export default unTypiaNext(config);
 ```
+
+Examples:
+- [`examples/nextjs`](https://github.com/ryoppippi/unplugin-typia/tree/main/examples/nextjs)
 
 <br></details>
 

--- a/packages/unplugin-typia/README.md
+++ b/packages/unplugin-typia/README.md
@@ -24,14 +24,22 @@ npx jsr add -D @ryoppippi/unplugin-typia
 Then, install `typia`:
 
 ```bash
+# install unplugin-typia!
 npx jsr add -D @ryoppippi/unplugin-typia
-npm install --save typia
-npx typia setup
 
+# install typia! (nypm detects your PM ✨)
+npx nypm add typia  
+
+# setup typia!
+npx typia setup
+# pnpm dlx typia setup
+# yarn dlx typia setup
+
+# after installing typia, run prepare script
 npm run prepare
 ```
 
-You should follow the [Setup Instruction](https://typia.io/docs/setup/#unplugin-typia) on the Typia website.
+More details about setting up Typia can be found in the [Typia Docs](https://typia.io/docs/setup/#unplugin-typia).
 
 Then, add the unplugin to your favorite bundler:
 


### PR DESCRIPTION
The examples list in the README has been expanded to include more
specific use cases. This includes examples for vite-vanilla, vite-react,
vite-hono, sveltekit, esbuild, and nextjs.