### PR TITLE
fix(readme): remove duplicate installation instruction

### DIFF
--- a/packages/unplugin-typia/README.md
+++ b/packages/unplugin-typia/README.md
@@ -24,9 +24,6 @@ npx jsr add -D @ryoppippi/unplugin-typia
 Then, install `typia`:
 
 ```bash
-# install unplugin-typia!
-npx jsr add -D @ryoppippi/unplugin-typia
-
 # install typia! (nypm detects your PM ✨)
 npx nypm add typia  
 


### PR DESCRIPTION
The installation instruction for `unplugin-typia` was duplicated in the README.md file. This commit removes the duplicate instruction to avoid confusion for users.