### PR TITLE
Improve cache handling and validation in unplugin-typia

### DIFF
--- a/packages/unplugin-typia/src/core/cache.ts
+++ b/packages/unplugin-typia/src/core/cache.ts
@@ -28,7 +28,7 @@ function getStorage(option: ResolvedCacheOptions): Storage {
 	});
 
 	if (globalStorage == null) {
-		throw new Error('Storage is not initialized');
+		throw new Error('Storage cannot be created');
 	}
 
 	return globalStorage;

--- a/packages/unplugin-typia/src/core/cache.ts
+++ b/packages/unplugin-typia/src/core/cache.ts
@@ -2,12 +2,14 @@ import { type Storage, createStorage } from 'unstorage';
 import fsLiteDriver from 'unstorage/drivers/fs-lite';
 import { isEqual, sha256 } from 'ohash';
 import type { transformTypia } from './typia.js';
-import type { CacheOptions, ResolvedCacheOptions } from './options.js';
+import type { ResolvedOptions } from './options.js';
+
+type ResolvedCacheOptions = ResolvedOptions['cache'];
 
 type Data = Awaited<ReturnType<typeof transformTypia>>;
 
 let globalStorage: Storage | undefined;
-let globalOption: CacheOptions | undefined;
+let globalOption: ResolvedCacheOptions | undefined;
 
 /**
  * Get storage

--- a/packages/unplugin-typia/src/core/options.ts
+++ b/packages/unplugin-typia/src/core/options.ts
@@ -61,7 +61,7 @@ export interface CacheOptions {
 	base?: string;
 };
 
-type ResolvedOptions = RequiredDeep<Omit<Options, 'typia'>> & { typia: Options['typia'] };
+export type ResolvedOptions = RequiredDeep<Omit<Options, 'typia' | 'cache'>> & { typia: Options['typia']; cache: Required<CacheOptions> };
 
 /** Default options */
 export const defaultOptions = ({


### PR DESCRIPTION


This pull request introduces several enhancements to the cache handling and validation in the `unplugin-typia` package:

1. Added a new `StoreData` interface to store additional metadata alongside the cached data, including the `id` and `source` properties. This allows for more robust cache validation.

2. Updated the `getCache` function to perform cache validation by comparing the stored `id` and `source` with the provided values. If there is a mismatch or the data is not found, `null` is returned.

3. Modified the `setCache` function to store the `StoreData` object, including the `data`, `id`, and `source` properties. If the provided `data` is `null`, the cache entry is removed using `removeItem`.

4. Refined error handling in the `getStorage` function by throwing a more descriptive error message when the storage cannot be created.

5. Updated the `ResolvedOptions` type to include the `cache` property as a required field of type `Required<CacheOptions>`.

6. Minor code cleanup and improvements, such as using `null` instead of `undefined` for consistency and removing unused imports.

These changes aim to improve the reliability and maintainability of the caching mechanism in `unplugin-typia`. Please let me know if you have any questions or feedback regarding this pull request.

