### PR TITLE
feat: Add deployment workflow and script

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,21 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - run: bun i --frozen-lockfile
+      - run: bun run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "turbo build",
     "lint": "turbo lint",
-    "test": "turbo test"
+    "test": "turbo test",
+    "deploy": "turbo deploy"
   },
   "workspaces": [
     "examples/*",

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,9 @@
     "dev": {
       "persistent": true,
       "cache": false
+    },
+    "deploy": {
+      "dependsOn": ["^deploy"]
     }
   }
 }


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow for deployment. It triggers on push to the main branch and on workflow dispatch. The workflow uses the setup-bun action with the latest bun version, installs dependencies with bun i --frozen-lockfile, and runs the newly added "deploy" script from package.json.

The "deploy" script has also been added as a dependency in turbo.json. A CLOUDFLARE_API_TOKEN environment variable is used during deployment, which is fetched from GitHub secrets.