### PR TITLE
feat(deploy.yaml): add environment to deploy job

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: main-example-deploy
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
An environment named 'main-example-deploy' has been added to the deploy job in the GitHub Actions workflow. This environment will be used for deploying the main example.