### PR TITLE
feat(core): export Options type from core

### DIFF
--- a/packages/unplugin-typia/src/core/index.ts
+++ b/packages/unplugin-typia/src/core/index.ts
@@ -102,6 +102,7 @@ const unplugin: UnpluginInstance<Options | undefined, false>
 /* #__PURE__ */ = createUnplugin(unpluginFactory);
 
 export {
+	type Options,
 	resolveOptions,
 	createFilter,
 	transformTypia,


### PR DESCRIPTION
The Options type has been exported from the core module. This change
provides better type support for external usage.
