### PR TITLE
feature/update next js doc

### DIFF
--- a/packages/unplugin-typia/README.md
+++ b/packages/unplugin-typia/README.md
@@ -92,9 +92,15 @@ Examples:
 import unTypiaNext from 'unplugin-typia/next';
 
 /** @type {import('next').NextConfig} */
-const config = {};
+const nextConfig = { /* your next.js config */};
 
-export default unTypiaNext(config);
+/** @type {import("unplugin-typia").Options} */
+const unpluginTypiaOptions = { /* your unplugin-typia options */ };
+
+export default unTypiaNext(nextConfig, unpluginTypiaOptions);
+
+// you can omit the unplugin-typia options when you don't need to customize it
+// export default unTypiaNext(nextConfig);
 ```
 
 Examples:

--- a/packages/unplugin-typia/jsr.json
+++ b/packages/unplugin-typia/jsr.json
@@ -2,7 +2,7 @@
 	"name": "@ryoppippi/unplugin-typia",
 	"version": "0.3.0",
 	"exports": {
-		"./index": "./src/index.ts",
+		".": "./src/index.ts",
 		"./api": "./src/api.ts",
 		"./vite": "./src/vite.ts",
 		"./webpack": "./src/webpack.ts",

--- a/packages/unplugin-typia/src/index.ts
+++ b/packages/unplugin-typia/src/index.ts
@@ -1,9 +1,3 @@
-/**
- * This entry file is for exporting unplugin.
- *
- * @module
- */
-
 import unplugin from './core/index.js';
 import type { CacheOptions, Options } from './core/options.js';
 

--- a/packages/unplugin-typia/src/next.ts
+++ b/packages/unplugin-typia/src/next.ts
@@ -15,9 +15,17 @@ import type { Options } from './core/options.js';
  * // next.config.mjs
  * import unTypiaNext from "unplugin-typia/next";
  *
- * export default unTypiaNext({
- *   // your next.js config @type {import('next').NextConfig}
- * })
+ * /** @type {import("next").NextConfig} *\/
+ * const nextConfig = { /* your next.js config *\/ };
+ *
+ * /** @type {import("unplugin-typia").Options} *\/
+ * const unpluginTypiaOptions = { /* your unplugin-typia options *\/ };
+ *
+ * // Export the next.js config
+ * export default unTypiaNext(
+ *	 nextConfig,
+ *   unpluginTypiaOptions // you can omit this when you don't need to customize it
+ * );
  * ```
  */
 function next(nextConfig: Record<string, any> = {}, options: Options): Record<string, any> {


### PR DESCRIPTION
This PR introduces several changes to the `unplugin-typia` package.

## Changes

1. **README.md**: The usage example for `unplugin-typia/next` has been updated. The new example shows how to pass both the Next.js configuration and the `unplugin-typia` options to `unTypiaNext`.

2. **jsr.json**: The main entry point for the package has been changed from `./index` to `.`.

3. **src/index.ts**: The introductory comments in this file have been removed.

4. **src/next.ts**: The comments in this file have been updated to reflect the changes in the usage example in the README.

These changes aim to improve the clarity of the usage examples and streamline the package's entry point.
