### PR TITLE
feat: add tsconfig path option to plugin options

### DIFF
--- a/packages/unplugin-typia/src/core/options.ts
+++ b/packages/unplugin-typia/src/core/options.ts
@@ -26,6 +26,13 @@ export interface Options {
 	enforce?: 'pre' | 'post' | undefined;
 
 	/**
+	 * The path to the tsconfig file.
+	 * If not specified, the plugin will try to find it automatically.
+	 * @default undefined
+	 */
+	tsconfig?: string;
+
+	/**
 	 * The options for the typia transformer.
 	 */
 	typia?: ITransformOptions;
@@ -61,7 +68,7 @@ export interface CacheOptions {
 	base?: string;
 };
 
-export type ResolvedOptions = RequiredDeep<Omit<Options, 'typia' | 'cache'>> & { typia: Options['typia']; cache: Required<CacheOptions> };
+export type ResolvedOptions = RequiredDeep<Omit<Options, 'typia' | 'cache' | 'tsconfig'>> & { typia: Options['typia']; cache: Required<CacheOptions>; tsconfig?: string };
 
 /** Default options */
 export const defaultOptions = ({

--- a/packages/unplugin-typia/src/core/typia.ts
+++ b/packages/unplugin-typia/src/core/typia.ts
@@ -38,7 +38,7 @@ export async function transformTypia(
 	const cacheEnable = options.cache.enable;
 
 	/** parse tsconfig compilerOptions */
-	compilerOptions = await getTsCompilerOption(cacheEnable);
+	compilerOptions = await getTsCompilerOption(cacheEnable, options?.tsconfig);
 
 	const { program, tsSource } = await getProgramAndSource(id, source, compilerOptions, cacheEnable);
 
@@ -56,9 +56,10 @@ export async function transformTypia(
 /**
  * Read tsconfig.json and get compilerOptions.
  * @param cacheEnable - Whether to enable cache. @default true
+ * @param tsconfigId - The tsconfig.json path. @default undefined
  */
-async function getTsCompilerOption(cacheEnable = true): Promise<ts.CompilerOptions> {
-	const parseTsComilerOptions = async () => (({ ...(await readTSConfig())?.compilerOptions, moduleResolution: undefined }));
+async function getTsCompilerOption(cacheEnable = true, tsconfigId?: string): Promise<ts.CompilerOptions> {
+	const parseTsComilerOptions = async () => (({ ...(await readTSConfig(tsconfigId))?.compilerOptions, moduleResolution: undefined }));
 
 	/** parse tsconfig compilerOptions */
 	if (cacheEnable) {


### PR DESCRIPTION
This commit introduces a new option 'tsconfig' in the plugin options.
This option allows users to specify the path to the tsconfig file.
If not specified, the plugin will try to find it automatically.
The 'tsconfig' option is also added to the 'ResolvedOptions' type.
The 'getTsCompilerOption' function now accepts an optional 'tsconfigId'
parameter, which is used when reading the tsconfig file.
