### PR TITLE
feat: Change default cache directory

### DIFF
--- a/packages/unplugin-typia/src/core/options.ts
+++ b/packages/unplugin-typia/src/core/options.ts
@@ -63,7 +63,7 @@ export interface CacheOptions {
 
 	/**
 	 * The base directory for cache.
-	 * @default '/tmp'
+	 * @default '/tmp/unplugin_typia'
 	 */
 	base?: string;
 };
@@ -76,7 +76,7 @@ export const defaultOptions = ({
 	exclude: [/node_modules/],
 	enforce: 'pre',
 	typia: { },
-	cache: { enable: true, base: '/tmp' },
+	cache: { enable: true, base: '/tmp/unplugin_typia' },
 	log: true,
 }) as const satisfies ResolvedOptions;
 

--- a/packages/unplugin-typia/test/options.ts
+++ b/packages/unplugin-typia/test/options.ts
@@ -49,7 +49,7 @@ test('Return cache object if cache key is object and not base passed', () => {
 	);
 	assertObjectMatch(options, {
 		...defaultOptions,
-		cache: { enable: false, base: '/tmp' },
+		cache: { enable: false, base: '/tmp/unplugin_typia' },
 	});
 });
 


### PR DESCRIPTION
The default cache directory has been changed from '/tmp' to
'/tmp/unplugin_typia'. This change has been reflected in the core
options and the unit tests.
