### PR TITLE
feat(unplugin-typia): add Bun.build examples to README and bun.ts/ enable cache for bun.ts

### DIFF
--- a/examples/bun-build/build.ts
+++ b/examples/bun-build/build.ts
@@ -1,0 +1,9 @@
+import UnpluginTypia from 'unplugin-typia/bun'
+
+await Bun.build({
+	entrypoints: ["./index.ts"],
+	outdir: "./out",
+	plugins: [
+    UnpluginTypia()
+	]
+});

--- a/examples/bun-build/package.json
+++ b/examples/bun-build/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "prepare": "ts-patch install && typia patch",
-    "test": "bun run ./index.ts"
+    "test": "bun run ./index.ts",
+    "build": "bun run ./build.ts"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/packages/unplugin-typia/README.md
+++ b/packages/unplugin-typia/README.md
@@ -110,6 +110,61 @@ Examples:
 <br></details>
 
 <details>
+<summary>Bun.build</summary><br>
+
+### Example 1: Using for running script
+
+```ts
+// preload.ts
+import { plugin } from 'bun';
+import UnpluginTypia from 'unplugin-typia/bun';
+
+plugin(UnpluginTypia({ /* your options */}));
+```
+
+```toml
+# bun.toml
+preload = "preload.ts"
+
+[test]
+preload = "preload.ts"
+```
+
+For running the script:
+
+```sh
+bun run ./index.ts
+```
+
+Check the [Plugins – Runtime | Bun Docs](https://bun.sh/docs/runtime/plugins) for more details.
+
+### Example 2: Using for building script
+
+```ts
+// build.ts
+import UnpluginTypia from 'unplugin-typia/bun';
+
+await Bun.build({
+	entrypoints: ['./index.ts'],
+	outdir: './out',
+	plugins: [
+		UnpluginTypia({ /* your options */})
+	]
+});
+```
+
+For building the script:
+
+```sh
+bun run ./build.ts
+node ./out/index.js
+```
+
+Check the [Plugins – Bundler | Bun Docs](https://bun.sh/docs/bundler/plugins) for more details.
+
+<br></details>
+
+<details>
 <summary>Rollup</summary><br>
 
 ```ts

--- a/packages/unplugin-typia/src/bun.ts
+++ b/packages/unplugin-typia/src/bun.ts
@@ -17,6 +17,8 @@ if (globalThis.Bun == null) {
  *
  * some typia functions does not works because of bun/typia internal implementation. see the [issse](https://github.com/ryoppippi/unplugin-typia/issues/44)
  * @experimental
+ * also check out hte [Bun.build docc](https://bun.sh/docs/bundler)
+ *
  * @example
  * ```ts
  * // preload.ts
@@ -26,12 +28,26 @@ if (globalThis.Bun == null) {
  * plugin(UnpluginTypia({ /* your options *\/}))
  * ```
  * ```toml
- * // bunfig.toml
+ * # bunfig.toml
  * preload = ["./preload.ts"]
  *
  * [test]
  * preload = ["./preload.ts"]
  * ```
+ *
+ * @example
+ * ```ts
+ * // build.ts
+ *
+ * import UnpluginTypia from 'unplugin-typia/bun'
+ *
+ * Bun.build({
+ *   entrypoints: ['./index.ts'],
+ *   outdir: './out',
+ *   plugins: [
+ *     UnpluginTypia({ /* your options *\/})
+ *  ]
+ * })
  */
 function bunTypiaPlugin(
 	options?: Options,

--- a/packages/unplugin-typia/src/bun.ts
+++ b/packages/unplugin-typia/src/bun.ts
@@ -5,7 +5,8 @@
  */
 
 import type { BunPlugin } from 'bun';
-import { type Options, resolveOptions, transformTypia } from './api.js';
+import type { UnpluginContextMeta } from 'unplugin';
+import { type Options, resolveOptions, unplugin } from './api.js';
 import { defaultOptions } from './core/options.js';
 
 if (globalThis.Bun == null) {
@@ -52,11 +53,23 @@ if (globalThis.Bun == null) {
 function bunTypiaPlugin(
 	options?: Options,
 ): BunPlugin {
+	const unpluginRaw = unplugin.raw(
+		options,
+		{} as UnpluginContextMeta,
+	);
+
+	const { transform } = unpluginRaw;
+
+	if (transform == null) {
+		throw new Error('transform is not defined');
+	}
+
 	const bunPlugin = ({
 		name: 'unplugin-typia',
 		setup(build) {
 			const resolvedOptions = resolveOptions(options ?? {});
 			const { include } = resolvedOptions;
+
 			const filter = include instanceof RegExp
 				? include
 				: typeof include === 'string'
@@ -70,16 +83,17 @@ function bunTypiaPlugin(
 
 				const source = await Bun.file(path).text();
 
-				const code = await transformTypia(
-					path,
-					source,
-					{ warn: console.warn } as Parameters<typeof transformTypia>[2],
-					resolvedOptions,
-				);
+				// @ts-expect-error type of this function is not correct
+				const result = await transform(source, path);
 
-				return {
-					contents: code ?? source,
-				};
+				switch (true) {
+					case result == null:
+						return { contents: source };
+					case typeof result === 'string':
+						return { contents: source };
+					default:
+						return { contents: result.code };
+				}
 			});
 		},
 	}) as const satisfies BunPlugin;


### PR DESCRIPTION
This commit adds two examples of how to use the unplugin-typia with
Bun.build in the README.md and bun.ts files. The first example shows
how to use it for running scripts, and the second one for building
scripts. It also updates the documentation in bun.ts to include these
examples and a link to the Bun.build documentation.