### PR TITLE
feat: add format script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "turbo build",
     "lint": "turbo lint",
+    "format": "turbo format",
     "test": "turbo test",
     "deploy": "turbo deploy"
   },

--- a/packages/unplugin-typia/package.json
+++ b/packages/unplugin-typia/package.json
@@ -53,6 +53,7 @@
 	],
 	"scripts": {
 		"lint": "npm run check && eslint .",
+		"format": "eslint --fix .",
 		"test": "npm run check && bun test ./test/*.ts",
 		"check": "bun tsc --noEmit",
 		"publish": "bun x jsr publish"

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,9 @@
     "lint": {
       "dependsOn": ["^lint"]
     },
+    "format": {
+      "dependsOn": ["^format"]
+    },
     "test": {
       "dependsOn": ["^test"]
     },


### PR DESCRIPTION
A new script 'format' has been added to the scripts section of
package.json in both the root directory and the unplugin-typia
package. This script will run the 'eslint --fix .' command to
automatically format the code according to the project's ESLint
rules. The turbo.json file has also been updated to include a
dependency for the 'format' script.
