### PR TITLE
feat(webpack): support 'cjs' target with 'jiti'

### DIFF
--- a/packages/unplugin-typia/README.md
+++ b/packages/unplugin-typia/README.md
@@ -185,9 +185,16 @@ export default {
 <details>
 <summary>Webpack</summary><br>
 
-```ts
+> ⚠️ Note: Currently, this plugin works only with 'esm' target. If you want to use 'cjs' target, please use with [`jiti`](https://github.com/unjs/jiti). Refer [this issue](https://github.com/samchon/typia/issues/1094).
+
+```sh
+npm install jiti
+```
+
+```js
 // webpack.config.js
-const UnpluginTypia = require('@ryoppippi/unplugin-typia/webpack');
+const jiti = require('jiti')();
+const UnpluginTypia = jiti('@ryoppippi/unplugin-typia/webpack').default;
 
 module.exports = {
 	plugins: [

--- a/packages/unplugin-typia/src/webpack.ts
+++ b/packages/unplugin-typia/src/webpack.ts
@@ -9,12 +9,20 @@ import unplugin from './core/index.js';
 /**
  * Webpack plugin
  *
+ * Currently, this plugin works only with 'esm' target. If you want to use 'cjs' target, please use with [`jiti`](https://github.com/unjs/jiti).
+ *
+ * Refer this issue https://github.com/samchon/typia/issues/1094
+ *
  * @example
- * ```ts
+ * ```js
  * // webpack.config.js
+ * const jiti = require("jiti")();
+ * const UnpluginTypia = jiti("@ryoppippi/unplugin-typia/webpack").default;
+ *
  * module.exports = {
- *  plugins: [require("@ryoppippi/unplugin-typia/webpack")()],
+ *  plugins: [UnpluginTypia({ /* your config *\/ })],
  * }
  * ```
+ *
  */
 export default unplugin.webpack;


### PR DESCRIPTION
This commit modifies the webpack plugin to support 'cjs' target by using 'jiti'. The previous version only supported 'esm' target. The usage example in the comments has been updated to reflect this change.

Refer to the issue https://github.com/samchon/typia/issues/1094 for more details.