### PR TITLE
feat: Add GitHub workflow for publishing package

### DIFF
--- a/.github/workflows/jsr.yaml
+++ b/.github/workflows/jsr.yaml
@@ -1,0 +1,35 @@
+name: jsr
+
+on:
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - run: bun i --frozen-lockfile
+      - id: get_version
+        name: Get version
+        uses: jannemattila/get-version-from-tag@v3
+      - name: jsr.json version to packge.json verion
+        run: |
+          jq --arg new_version "${{ steps.get_version.outputs.version }}" '.version = $new_version' package.json > package.tmp.json && mv package.tmp.json package.json
+          jq --arg new_version "${{ steps.get_version.outputs.version }}" '.version = $new_version' jsr.json > jsr.tmp.json && mv jsr.tmp.json jsr.json
+        working-directory: packages/unplugin-typia
+      - name: Publish
+        if: github.ref == 'refs/tags/v*'
+        run: bun run publish
+        working-directory: packages/unplugin-typia

--- a/packages/unplugin-typia/jsr.json
+++ b/packages/unplugin-typia/jsr.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ryoppippi/unplugin-typia",
-	"version": "0.3.10",
+	"version": "0.0.0",
 	"exports": {
 		".": "./src/index.ts",
 		"./api": "./src/api.ts",

--- a/packages/unplugin-typia/package.json
+++ b/packages/unplugin-typia/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@ryoppippi/unplugin-typia",
 	"type": "module",
-	"version": "0.3.10",
+	"version": "0.0.0",
 	"description": "unplugin for typia",
 	"author": "ryoppippi",
 	"license": "MIT",


### PR DESCRIPTION
This commit introduces a new GitHub workflow named 'jsr'. This workflow is triggered on push events for tags and on workflow dispatch. It sets up the environment with the latest version of 'bun', installs dependencies, fetches the version from the tag, updates the version in package.json and jsr.json, and finally publishes the package if the ref is a version tag.