### PR TITLE
feat: Add GitHub workflow for jsr

### DIFF
--- a/.github/workflows/jsr.yaml
+++ b/.github/workflows/jsr.yaml
@@ -1,0 +1,24 @@
+name: jsr
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - run: bun i --frozen-lockfile
+      - run: bun run publish
+        working-directory: packages/unplugin-typia


### PR DESCRIPTION
This commit introduces a new GitHub workflow named 'jsr'. It triggers
on push events for tags starting with "v". The workflow has read
permissions for contents and write permissions for id-token. It
runs on ubuntu-latest and includes steps for checkout, install
dependencies with frozen lockfile, and publish from the
'packages/unplugin-typia' directory.
