### PR TITLE
feat(README): add limitation note for Bun.runtime usage

### DIFF
--- a/packages/unplugin-typia/README.md
+++ b/packages/unplugin-typia/README.md
@@ -138,6 +138,20 @@ Check the [Plugins – Bundler | Bun Docs](https://bun.sh/docs/bundler/plugins) 
 
 ### Example 2: Using for running script
 
+> ⚠️ Limitation: you need import `typia` module as default import in your script.
+> Type named import is fine
+>
+> ```ts
+> import type { tag } from 'typia'; // do
+> import typia from 'typia'; // do
+> ```
+>
+> ```ts
+> import { createIs } from 'typia'; // don't
+> ```
+>
+> This is due to `Bun`'s bug. See [this issue](https://github.com/ryoppippi/unplugin-typia/issues/44)
+
 ```ts
 // preload.ts
 import { plugin } from 'bun';

--- a/packages/unplugin-typia/src/bun.ts
+++ b/packages/unplugin-typia/src/bun.ts
@@ -126,6 +126,7 @@ async function resolveTypiaPath(id: string, code: string, options: ResolvedBunOp
  * $ bun run ./index.ts
  * ```
  *
+ * When you run your scripts on Bun.runtime, You cannot use named import for typia value in the source code. Check out the README.md.
  */
 function bunTypiaPlugin(
 	options?: BunOptions,


### PR DESCRIPTION
This commit adds a note about a limitation when using the script. Users need to import the `typia` module as a default import in their script. Type named import is fine. This is due to a bug in `Bun`. A link to the related issue is also provided for more context.