### PR TITLE
fix(readme): remove limitation section

### DIFF
--- a/packages/unplugin-typia/README.md
+++ b/packages/unplugin-typia/README.md
@@ -138,20 +138,6 @@ Check the [Plugins – Bundler | Bun Docs](https://bun.sh/docs/bundler/plugins) 
 
 ### Example 2: Using for running script
 
-> ⚠️ Limitation: you need import `typia` module as default import in your script.
-> Type named import is fine
->
-> ```ts
-> import type { tag } from 'typia'; // do
-> import typia from 'typia'; // do
-> ```
->
-> ```ts
-> import { createIs } from 'typia'; // don't
-> ```
->
-> This is due to `Bun`'s bug. See [this issue](https://github.com/ryoppippi/unplugin-typia/issues/44)
-
 ```ts
 // preload.ts
 import { plugin } from 'bun';


### PR DESCRIPTION
This PR removes the section in the README that describes a limitation related to the import of the `typia` module. The limitation was that `typia` had to be imported as a default import in scripts, and named imports were not allowed. This was due to a bug in `Bun`. 

The removal of this section suggests that the bug has been fixed and the limitation no longer applies. Users can now import `typia` in any way they prefer in their scripts.

fixes: #99 
