### PR TITLE
feat: add isBun utility function

### DIFF
--- a/packages/unplugin-typia/src/bun.ts
+++ b/packages/unplugin-typia/src/bun.ts
@@ -9,8 +9,9 @@ import type { UnpluginContextMeta } from 'unplugin';
 import { hasCJSSyntax } from 'mlly';
 import { resolveOptions, unplugin } from './api.js';
 import { type Options, type ResolvedOptions, defaultOptions } from './core/options.js';
+import { isBun } from './core/utils.js';
 
-if (globalThis.Bun == null) {
+if (isBun()) {
 	throw new Error('You must use this plugin with bun');
 }
 

--- a/packages/unplugin-typia/src/core/utils.ts
+++ b/packages/unplugin-typia/src/core/utils.ts
@@ -6,3 +6,7 @@ export function log(
 ) {
 	consola[type](`[unplugin-typia]`, ...args);
 }
+
+export function isBun() {
+	return globalThis.Bun != null;
+}


### PR DESCRIPTION
This commit introduces a new utility function `isBun` which checks if
`globalThis.Bun` is not nullish. This function is now used in `bun.ts` to
throw an error if the plugin is not used with bun.
