### PR TITLE
fix(bun.ts): correct condition for bun check

### DIFF
--- a/packages/unplugin-typia/src/bun.ts
+++ b/packages/unplugin-typia/src/bun.ts
@@ -11,7 +11,7 @@ import { resolveOptions, unplugin } from './api.js';
 import { type Options, type ResolvedOptions, defaultOptions } from './core/options.js';
 import { isBun } from './core/utils.js';
 
-if (isBun()) {
+if (!isBun()) {
 	throw new Error('You must use this plugin with bun');
 }
 


### PR DESCRIPTION
The condition for checking if the environment is 'bun' was incorrect.
It was throwing an error when it was 'bun', but it should throw an
error when it is not 'bun'. This commit corrects this condition.
