### PR TITLE
feat(examples/bun-build): Enable cache and verbose logging in UnpluginTypia

### DIFF
--- a/examples/bun-build/preload.ts
+++ b/examples/bun-build/preload.ts
@@ -1,4 +1,4 @@
 import { plugin } from 'bun';
 import UnpluginTypia from '@ryoppippi/unplugin-typia/bun'
 
-plugin(UnpluginTypia({cache: false}))
+plugin(UnpluginTypia({cache: true, log: 'verbose'}))


### PR DESCRIPTION
This commit enables caching and sets the logging level to verbose
for the UnpluginTypia plugin in the bun-build example. This change
should improve performance and provide more detailed logs for
debugging.
