### PR TITLE
feat(cache): update cache directory handling

### DIFF
--- a/packages/unplugin-typia/src/core/options.ts
+++ b/packages/unplugin-typia/src/core/options.ts
@@ -2,6 +2,7 @@ import type { RequiredDeep } from 'type-fest';
 import { createDefu } from 'defu';
 import type { FilterPattern } from '@rollup/pluginutils';
 import type { ITransformOptions } from 'typia/lib/transformers/ITransformOptions.js';
+import { getCacheDir } from './cache.js';
 
 /**
  * Represents the options for the plugin.
@@ -39,10 +40,10 @@ export interface Options {
 
 	/**
 	 * The optiosn for cache.
-	 * if `true`, it will enable cache with default path.
+	 * if `true`, it will enable cache with and will use node_modules/.cache/unplugin_typia (if exists) or {TMP_DIR}/unplugin_typia
 	 * if `false`, it will disable cache.
 	 * if object, it will enable cache with custom path.
-	 * @default { enable: true, base: '/tmp/unplugin_typia' }
+	 * @default { enable: true, base: /* TMP_DIR *\/ }
 	 */
 	cache?: CacheOptions | true | false;
 
@@ -78,7 +79,7 @@ export const defaultOptions = ({
 	exclude: [/node_modules/],
 	enforce: 'pre',
 	typia: { },
-	cache: { enable: true, base: '/tmp/unplugin_typia' },
+	cache: { enable: true, base: getCacheDir() },
 	log: true,
 }) as const satisfies ResolvedOptions;
 


### PR DESCRIPTION
This commit updates the cache directory handling in the unplugin-typia package. It introduces a new function `getCacheDir` that determines the cache directory based on the system's temporary directory. This function also includes a workaround for an issue with pnpm setting an incorrect `TMPDIR`. The default cache base path has been updated to use this new function. The changes are reflected in the `Options` interface and the default options.