### PR TITLE
Refactor code to use tagged types for better type safety

### DIFF
--- a/packages/unplugin-typia/src/core/index.ts
+++ b/packages/unplugin-typia/src/core/index.ts
@@ -11,6 +11,7 @@ import { resolveOptions } from './options.js';
 import { transformTypia } from './typia.js';
 import { getCache, setCache } from './cache.js';
 import { log } from './utils.js';
+import { type ID, type Source, wrap } from './types.js';
 
 const name = `unplugin-typia`;
 
@@ -53,7 +54,10 @@ const unpluginFactory: UnpluginFactory<
 			return filter(id);
 		},
 
-		async transform(source, id) {
+		async transform(_source, _id) {
+			const source = wrap<Source>(_source);
+			const id = wrap<ID>(_id);
+
 			/** get cache */
 			let code = await getCache(id, source, cacheOptions);
 

--- a/packages/unplugin-typia/src/core/options.ts
+++ b/packages/unplugin-typia/src/core/options.ts
@@ -1,4 +1,4 @@
-import type { RequiredDeep } from 'type-fest';
+import type { OverrideProperties, RequiredDeep } from 'type-fest';
 import { createDefu } from 'defu';
 import type { FilterPattern } from '@rollup/pluginutils';
 import type { ITransformOptions } from 'typia/lib/transformers/ITransformOptions.js';
@@ -72,7 +72,15 @@ export interface CacheOptions {
 	base?: string;
 };
 
-export type ResolvedOptions = RequiredDeep<Omit<Options, 'typia' | 'cache' | 'tsconfig'>> & { typia: Options['typia']; cache: Pick<Required<CacheOptions>, 'enable'> & { base: FilePath }; tsconfig?: string };
+export type ResolvedOptions
+	= OverrideProperties<
+		RequiredDeep<Options>,
+		{
+			typia: Options['typia'];
+			tsconfig: Options['tsconfig'];
+			cache: RequiredDeep<OverrideProperties<CacheOptions, { base: FilePath } >>;
+		}
+	>;
 
 /** Default options */
 export const defaultOptions = ({
@@ -82,6 +90,7 @@ export const defaultOptions = ({
 	typia: { },
 	cache: { enable: true, base: getCacheDir() },
 	log: true,
+	tsconfig: undefined,
 }) as const satisfies ResolvedOptions;
 
 /** Create custom defu instance */

--- a/packages/unplugin-typia/src/core/options.ts
+++ b/packages/unplugin-typia/src/core/options.ts
@@ -3,6 +3,7 @@ import { createDefu } from 'defu';
 import type { FilterPattern } from '@rollup/pluginutils';
 import type { ITransformOptions } from 'typia/lib/transformers/ITransformOptions.js';
 import { getCacheDir } from './cache.js';
+import { type FilePath, wrap } from './types.js';
 
 /**
  * Represents the options for the plugin.
@@ -71,7 +72,7 @@ export interface CacheOptions {
 	base?: string;
 };
 
-export type ResolvedOptions = RequiredDeep<Omit<Options, 'typia' | 'cache' | 'tsconfig'>> & { typia: Options['typia']; cache: Required<CacheOptions>; tsconfig?: string };
+export type ResolvedOptions = RequiredDeep<Omit<Options, 'typia' | 'cache' | 'tsconfig'>> & { typia: Options['typia']; cache: Pick<Required<CacheOptions>, 'enable'> & { base: FilePath }; tsconfig?: string };
 
 /** Default options */
 export const defaultOptions = ({
@@ -99,13 +100,15 @@ const defu = createDefu((obj, key, value) => {
  * @returns The resolved options.
  */
 export function resolveOptions(options: Options): ResolvedOptions {
+	const { cache } = options;
+
 	return defu(
 		{
 			...options,
 			cache:
-				typeof options.cache === 'boolean'
-					? { enable: options.cache }
-					: options.cache,
+				typeof cache === 'boolean'
+					? { enable: cache }
+					: { ...cache, base: cache?.base != null ? wrap<FilePath>(cache.base) : undefined },
 		},
 		defaultOptions,
 	);

--- a/packages/unplugin-typia/src/core/types.ts
+++ b/packages/unplugin-typia/src/core/types.ts
@@ -1,0 +1,15 @@
+import type { Tagged, UnwrapTagged } from 'type-fest';
+
+export type CacheKey = Tagged<string, 'cache-key'>;
+export type CachePath = Tagged<string, 'cache-path'>;
+export type ID = Tagged<string, 'id'>;
+export type Source = Tagged<string, 'source'>;
+export type FilePath = Tagged<string, 'file-path'>;
+
+export function wrap<T extends Tagged<PropertyKey, any>>(value: UnwrapTagged<T>): T {
+	return value as T;
+}
+
+export function unwrap<T extends Tagged<PropertyKey, any>>(value: T): UnwrapTagged<T> {
+	return value as UnwrapTagged<T>;
+}

--- a/packages/unplugin-typia/src/core/typia.ts
+++ b/packages/unplugin-typia/src/core/typia.ts
@@ -5,6 +5,7 @@ import type { UnpluginBuildContext, UnpluginContext } from 'unplugin';
 import { transform as typiaTransform } from 'typia/lib/transform.js';
 
 import type { ResolvedOptions } from './options.ts';
+import type { ID, Source } from './types.js';
 
 /** create a printer */
 const printer = ts.createPrinter();
@@ -25,8 +26,8 @@ const sourceCache = new Map<string, ts.SourceFile>();
  * @returns The transformed code.
  */
 export async function transformTypia(
-	id: string,
-	source: string,
+	id: ID,
+	source: Source,
 	/**
 	 * **Use with caution.**
 	 *
@@ -86,8 +87,8 @@ async function getTsCompilerOption(cacheEnable = true, tsconfigId?: string): Pro
  * @returns The program and source.
  */
 async function getProgramAndSource(
-	id: string,
-	source: string,
+	id: ID,
+	source: Source,
 	compilerOptions: ts.CompilerOptions,
 	cacheEnable = true,
 ): Promise<{ program: ts.Program; tsSource: ts.SourceFile }> {
@@ -137,7 +138,7 @@ async function getProgramAndSource(
  * @returns The transformed code and source map.
  */
 function transform(
-	id: string,
+	id: ID,
 	program: ts.Program,
 	tsSource: ts.SourceFile,
 	typiaOptions?: ResolvedOptions['typia'],

--- a/packages/unplugin-typia/test/cache.ts
+++ b/packages/unplugin-typia/test/cache.ts
@@ -3,10 +3,12 @@ import { test } from 'bun:test';
 import { assertEquals, assertNotEquals } from '@std/assert';
 
 import * as cache from '../src/core/cache.js';
+import type { FilePath, ID, Source } from '../src/core/types.js';
+import { wrap } from '../src/core/types.js';
 
 type Data = Parameters<typeof cache.setCache>[2];
 
-const tmp = tmpdir();
+const tmp = wrap<FilePath>(tmpdir());
 
 function removeComments(data: string | null) {
 	if (data == null) {
@@ -20,21 +22,23 @@ function removeComments(data: string | null) {
 test('return null if cache is not found', async () => {
 	const option = { enable: true, base: tmp } as const;
 	const random = Math.random().toString();
-	const data = await cache.getCache(random, random, option);
+	const source = wrap<Source>(random);
+	const data = await cache.getCache(wrap<ID>(random), source, option);
 	assertEquals(data, null);
 });
 
 test('set and get cache', async () => {
 	const option = { enable: true, base: tmp } as const;
 	const random = Math.random().toString();
-	const filename = `${random}-${random}.json`;
+	const source = wrap<Source>(random);
+	const filename = wrap<ID>(`${random}-${random}.json`);
 	const data = `${random};` as const satisfies Data;
 
 	/* set cache */
-	await cache.setCache(filename, random, data, option);
+	await cache.setCache(filename, source, data, option);
 
 	/* get cache */
-	const cacheData = await cache.getCache(filename, random, option);
+	const cacheData = await cache.getCache(filename, source, option);
 
 	/* delete js asterisk comments */
 	const cacheDataStr = removeComments(cacheData);
@@ -45,14 +49,15 @@ test('set and get cache', async () => {
 test('set and get null with different id', async () => {
 	const option = { enable: true, base: tmp } as const;
 	const random = Math.random().toString();
-	const filename = `${random}-${random}.json`;
+	const source = wrap<Source>(random);
+	const filename = wrap<ID>(`${random}-${random}.json`);
 	const data = `${random};` as const satisfies Data;
 
 	/* set cache */
-	await cache.setCache(filename, random, data, option);
+	await cache.setCache(filename, source, data, option);
 
 	/* get cache */
-	const cacheData = await cache.getCache(`111;${random}`, random, option);
+	const cacheData = await cache.getCache(`111;${random}` as ID, source, option);
 
 	/* delete js asterisk comments */
 	const cacheDataStr = removeComments(cacheData);
@@ -64,14 +69,15 @@ test('set and get null with different id', async () => {
 test('set and get null with cache disabled', async () => {
 	const option = { enable: false, base: tmp } as const;
 	const random = Math.random().toString();
-	const filename = `${random}-${random}.json`;
+	const source = wrap<Source>(random);
+	const filename = wrap<ID>(`${random}-${random}.json`);
 	const data = `${random};` as const satisfies Data;
 
 	/* set cache */
-	await cache.setCache(filename, random, data, option);
+	await cache.setCache(filename, source, data, option);
 
 	/* get cache */
-	const cacheData = await cache.getCache(filename, random, option);
+	const cacheData = await cache.getCache(filename, source, option);
 
 	assertEquals(cacheData, null);
 });

--- a/packages/unplugin-typia/test/options.ts
+++ b/packages/unplugin-typia/test/options.ts
@@ -49,7 +49,7 @@ test('Return cache object if cache key is object and not base passed', () => {
 	);
 	assertObjectMatch(options, {
 		...defaultOptions,
-		cache: { enable: false, base: '/tmp/unplugin_typia' },
+		cache: { enable: false, base: defaultOptions.cache.base },
 	});
 });
 

--- a/packages/unplugin-typia/test/typia.ts
+++ b/packages/unplugin-typia/test/typia.ts
@@ -8,6 +8,7 @@ import {
 import type { UnpluginBuildContext, UnpluginContext } from 'unplugin';
 import { transformTypia } from '../src/core/typia.js';
 import { resolveOptions } from '../src/api.js';
+import type { ID, Source } from '../src/core/types.js';
 
 class DummyContext {
 	warn(args: unknown) {
@@ -50,7 +51,7 @@ const res = check({});
 console.log({ res });
 `;
 
-	const result = await transformTypia('test.ts', code, new DummyContext() as UnpluginContext & UnpluginBuildContext, resolveOptions({ cache: false }));
+	const result = await transformTypia('test.ts' as ID, code as Source, new DummyContext() as UnpluginContext & UnpluginBuildContext, resolveOptions({ cache: false }));
 	assertNotEquals(result, undefined);
 
 	if (result == null) {


### PR DESCRIPTION
This PR introduces several changes to the `unplugin-typia` package, primarily focusing on type safety and code refactoring. Here are the key changes:

1. **Introduction of Tagged Types**: The PR introduces several new tagged types (`ID`, `Source`, `CacheKey`, `CachePath`, `FilePath`) to improve type safety across the codebase. These types are used to wrap and unwrap values, ensuring that they are used correctly in their respective contexts.

2. **Refactoring of Transform Functions**: The transform functions in `bun.ts` and `typia.ts` have been refactored to use the new tagged types. This includes the introduction of a new `taggedTransform` function in `bun.ts`.

3. **Changes to Cache Handling**: The cache handling functions in `cache.ts` have been updated to use the new tagged types. This includes changes to the `getCache` and `setCache` functions, as well as the `getKey` and `getCachePath` helper functions.

4. **Updates to Options Handling**: The options handling in `options.ts` has been updated to use the new `FilePath` tagged type. The `ResolvedOptions` type has also been updated to reflect these changes.

5. **New Types File**: A new `types.ts` file has been added to the `core` directory, which contains the definitions for the new tagged types and their associated helper functions.

6. **Test Updates**: The tests in `cache.ts`, `options.ts`, and `typia.ts` have been updated to use the new tagged types.
