### PR TITLE
 Refactor Data Type and Import Statements in unplugin-typia

### DIFF
--- a/packages/unplugin-typia/src/core/cache.ts
+++ b/packages/unplugin-typia/src/core/cache.ts
@@ -5,15 +5,12 @@ import { tmpdir } from 'node:os';
 import process from 'node:process';
 import { basename, dirname, join } from 'pathe';
 import { readPackageJSON } from 'pkg-types';
-import type { CacheKey, CachePath, FilePath, ID, Source } from './types.js';
+import type { CacheKey, CachePath, Data, FilePath, ID, Source } from './types.js';
 import { wrap } from './types.js';
-import type { transformTypia } from './typia.js';
 import type { ResolvedOptions } from './options.js';
 import { isBun } from './utils.js';
 
 type ResolvedCacheOptions = ResolvedOptions['cache'];
-
-type Data = Awaited<ReturnType<typeof transformTypia>>;
 
 let cacheDir: string | null = null;
 let typiaVersion: string | undefined;
@@ -37,7 +34,7 @@ export async function getCache(
 	const key = getKey(id, source);
 	const path = getCachePath(key, option);
 
-	let data: Data | null = null;
+	let data: string | null = null;
 	if (isBun()) {
 		const file = Bun.file(path);
 		if (!(await file.exists())) {
@@ -55,7 +52,7 @@ export async function getCache(
 	const hashComment = await getHashComment(key);
 
 	if (data.endsWith(hashComment)) {
-		return data;
+		return wrap<Data>(data);
 	}
 
 	return null;

--- a/packages/unplugin-typia/src/core/index.ts
+++ b/packages/unplugin-typia/src/core/index.ts
@@ -11,7 +11,8 @@ import { resolveOptions } from './options.js';
 import { transformTypia } from './typia.js';
 import { getCache, setCache } from './cache.js';
 import { log } from './utils.js';
-import { type ID, type Source, wrap } from './types.js';
+import type { ID, Source } from './types.js';
+import { wrap } from './types.js';
 
 const name = `unplugin-typia`;
 

--- a/packages/unplugin-typia/src/core/types.ts
+++ b/packages/unplugin-typia/src/core/types.ts
@@ -5,6 +5,7 @@ export type CachePath = Tagged<string, 'cache-path'>;
 export type ID = Tagged<string, 'id'>;
 export type Source = Tagged<string, 'source'>;
 export type FilePath = Tagged<string, 'file-path'>;
+export type Data = Tagged<string, 'data'>;
 
 export function wrap<T extends Tagged<PropertyKey, any>>(value: UnwrapTagged<T>): T {
 	return value as T;

--- a/packages/unplugin-typia/src/core/typia.ts
+++ b/packages/unplugin-typia/src/core/typia.ts
@@ -5,7 +5,8 @@ import type { UnpluginBuildContext, UnpluginContext } from 'unplugin';
 import { transform as typiaTransform } from 'typia/lib/transform.js';
 
 import type { ResolvedOptions } from './options.ts';
-import type { ID, Source } from './types.js';
+import type { Data, ID, Source } from './types.js';
+import { wrap } from './types.js';
 
 /** create a printer */
 const printer = ts.createPrinter();
@@ -35,7 +36,7 @@ export async function transformTypia(
 	 */
 	unpluginContext: UnpluginBuildContext & UnpluginContext,
 	options: ResolvedOptions,
-): Promise<string> {
+): Promise<Data> {
 	/** Whether to enable cache */
 	const cacheEnable = options.cache.enable;
 
@@ -52,7 +53,8 @@ export async function transformTypia(
 
 	warnDiagnostic(diagnostics, transformed, unpluginContext);
 
-	return printer.printFile(file);
+	const data = printer.printFile(file);
+	return wrap<Data>(data);
 }
 
 /**

--- a/packages/unplugin-typia/test/cache.ts
+++ b/packages/unplugin-typia/test/cache.ts
@@ -3,10 +3,8 @@ import { test } from 'bun:test';
 import { assertEquals, assertNotEquals } from '@std/assert';
 
 import * as cache from '../src/core/cache.js';
-import type { FilePath, ID, Source } from '../src/core/types.js';
+import type { Data, FilePath, ID, Source } from '../src/core/types.js';
 import { wrap } from '../src/core/types.js';
-
-type Data = Parameters<typeof cache.setCache>[2];
 
 const tmp = wrap<FilePath>(tmpdir());
 
@@ -32,7 +30,7 @@ test('set and get cache', async () => {
 	const random = Math.random().toString();
 	const source = wrap<Source>(random);
 	const filename = wrap<ID>(`${random}-${random}.json`);
-	const data = `${random};` as const satisfies Data;
+	const data = wrap<Data>(`${random};`);
 
 	/* set cache */
 	await cache.setCache(filename, source, data, option);
@@ -51,7 +49,7 @@ test('set and get null with different id', async () => {
 	const random = Math.random().toString();
 	const source = wrap<Source>(random);
 	const filename = wrap<ID>(`${random}-${random}.json`);
-	const data = `${random};` as const satisfies Data;
+	const data = wrap<Data>(`${random};`);
 
 	/* set cache */
 	await cache.setCache(filename, source, data, option);
@@ -71,7 +69,7 @@ test('set and get null with cache disabled', async () => {
 	const random = Math.random().toString();
 	const source = wrap<Source>(random);
 	const filename = wrap<ID>(`${random}-${random}.json`);
-	const data = `${random};` as const satisfies Data;
+	const data = wrap<Data>(`${random};`);
 
 	/* set cache */
 	await cache.setCache(filename, source, data, option);


### PR DESCRIPTION
### Description:

This PR includes several changes to the `unplugin-typia` package, primarily focused on refactoring the handling of the `Data` type and adjusting import statements for better clarity and organization.

### Changes:

1. In `core/cache.ts`, the `Data` type has been imported from `types.js` instead of being defined within the file. The `transformTypia` import has been removed. The `data` variable's type has been changed from `Data` to `string`.

2. In `core/index.ts`, the import statement has been adjusted to separate type imports from regular imports for better clarity.

3. In `core/types.ts`, a new `Data` type has been added.

4. In `core/typia.ts`, the `Data` type has been imported from `types.js`. The `transformTypia` function now returns a `Promise<Data>` instead of `Promise<string>`, and the returned data is wrapped using the `wrap` function from `types.js`.

These changes aim to improve the clarity and maintainability of the code by ensuring that types are defined in a central location and used consistently across files.
