### PR TITLE
feat(cache): cosmetic cache validation logic

### DIFF
--- a/packages/unplugin-typia/src/core/cache.ts
+++ b/packages/unplugin-typia/src/core/cache.ts
@@ -51,11 +51,12 @@ export async function getCache(
 
 	const hashComment = await getHashComment(key);
 
-	if (data.endsWith(hashComment)) {
-		return wrap<Data>(data);
+	/* if data does not end with hashComment, the cache is invalid */
+	if (!data.endsWith(hashComment)) {
+		return null;
 	}
 
-	return null;
+	return wrap<Data>(data);
 }
 
 /**


### PR DESCRIPTION
The cache validation logic in `getCache` function has been updated. Previously, it returned the cache data if it ended with `hashComment`. Now, it returns null if the data does not end with `hashComment`, indicating that it's not a valid cache. This change improves the accuracy of cache validation.