### PR TITLE
feat: change build script in bun-build package.json

### DIFF
--- a/examples/bun-build/package.json
+++ b/examples/bun-build/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "bun run --watch ./index.ts",
     "start": "bun run ./index.ts",
-    "build": "bun build --entry ./index.ts --outdir ./out",
+    "build": "bun run ./build.ts",
     "prepare": "ts-patch install && typia patch"
   },
   "devDependencies": {


### PR DESCRIPTION
The build script in the bun-build package.json file has been updated.
Previously, it was directly building the index.ts file. Now, it runs
the build.ts file instead. This change provides more flexibility for
the build process.
