### PR TITLE
refactor(cache): convert cache operations to a class

### DIFF
--- a/packages/unplugin-typia/src/core/index.ts
+++ b/packages/unplugin-typia/src/core/index.ts
@@ -9,10 +9,10 @@ import MagicString from 'magic-string';
 import type { CacheOptions, Options } from './options.js';
 import { resolveOptions } from './options.js';
 import { transformTypia } from './typia.js';
-import { getCache, setCache } from './cache.js';
 import { log } from './utils.js';
 import type { ID, Source } from './types.js';
 import { wrap } from './types.js';
+import { Cache } from './cache.js';
 
 const name = `unplugin-typia`;
 
@@ -60,7 +60,8 @@ const unpluginFactory: UnpluginFactory<
 			const id = wrap<ID>(_id);
 
 			/** get cache */
-			let code = await getCache(id, source, cacheOptions);
+			using cache = cacheOptions.enable ? new Cache(id, source, cacheOptions) : undefined;
+			let code = cache?.data;
 
 			if (showLog) {
 				if (code != null) {
@@ -85,7 +86,9 @@ const unpluginFactory: UnpluginFactory<
 				}
 
 				/** save cache */
-				await setCache(id, source, code, cacheOptions);
+				if (cache != null) {
+					cache.data = code;
+				}
 
 				if (showLog) {
 					log('success', `Cache set: ${id}`);

--- a/packages/unplugin-typia/test/cache.ts
+++ b/packages/unplugin-typia/test/cache.ts
@@ -2,13 +2,13 @@ import { tmpdir } from 'node:os';
 import { test } from 'bun:test';
 import { assertEquals, assertNotEquals } from '@std/assert';
 
-import * as cache from '../src/core/cache.js';
+import { Cache } from '../src/core/cache.js';
 import type { Data, FilePath, ID, Source } from '../src/core/types.js';
 import { wrap } from '../src/core/types.js';
 
 const tmp = wrap<FilePath>(tmpdir());
 
-function removeComments(data: string | null) {
+function removeComments(data: string | undefined) {
 	if (data == null) {
 		return data;
 	}
@@ -21,8 +21,8 @@ test('return null if cache is not found', async () => {
 	const option = { enable: true, base: tmp } as const;
 	const random = Math.random().toString();
 	const source = wrap<Source>(random);
-	const data = await cache.getCache(wrap<ID>(random), source, option);
-	assertEquals(data, null);
+	using cache = new Cache(wrap<ID>(random), source, option);
+	assertEquals(cache.data, undefined);
 });
 
 test('set and get cache', async () => {
@@ -33,15 +33,18 @@ test('set and get cache', async () => {
 	const data = wrap<Data>(`${random};`);
 
 	/* set cache */
-	await cache.setCache(filename, source, data, option);
+	{
+		using cache = new Cache(filename, source, option);
+		cache.data = data;
+	}
 
 	/* get cache */
-	const cacheData = await cache.getCache(filename, source, option);
+	using cache = new Cache(filename, source, option);
 
 	/* delete js asterisk comments */
-	const cacheDataStr = removeComments(cacheData);
+	const cacheDataStr = removeComments(cache.data);
 
-	assertEquals(data, cacheDataStr);
+	assertEquals(cacheDataStr, data);
 });
 
 test('set and get null with different id', async () => {
@@ -52,30 +55,17 @@ test('set and get null with different id', async () => {
 	const data = wrap<Data>(`${random};`);
 
 	/* set cache */
-	await cache.setCache(filename, source, data, option);
+	{
+		using cache = new Cache(filename, source, option);
+		cache.data = data;
+	}
 
 	/* get cache */
-	const cacheData = await cache.getCache(`111;${random}` as ID, source, option);
+	using cache = new Cache(wrap<ID>(`111;${random}`), source, option);
 
 	/* delete js asterisk comments */
-	const cacheDataStr = removeComments(cacheData);
+	const cacheDataStr = removeComments(cache.data);
 
-	assertEquals(cacheDataStr, null);
-	assertNotEquals(data, cacheDataStr);
-});
-
-test('set and get null with cache disabled', async () => {
-	const option = { enable: false, base: tmp } as const;
-	const random = Math.random().toString();
-	const source = wrap<Source>(random);
-	const filename = wrap<ID>(`${random}-${random}.json`);
-	const data = wrap<Data>(`${random};`);
-
-	/* set cache */
-	await cache.setCache(filename, source, data, option);
-
-	/* get cache */
-	const cacheData = await cache.getCache(filename, source, option);
-
-	assertEquals(cacheData, null);
+	assertEquals(cacheDataStr, undefined);
+	assertNotEquals(cacheDataStr, data);
 });


### PR DESCRIPTION
The cache operations were previously handled by separate functions. This commit refactors the cache operations into a class, providing a more structured and object-oriented approach. The Cache class provides methods for getting and setting cache data, and handles hash key generation and cache directory management internally. This change simplifies the cache usage in the main codebase.