### PR TITLE
feat(FUNDING): add GitHub sponsorship link

### DIFF
--- a/.github/FUNDING.yaml
+++ b/.github/FUNDING.yaml
@@ -1,0 +1,1 @@
+github: ryoppippi


### PR DESCRIPTION
This commit introduces a new FUNDING.yaml file under the .github
directory. The file contains a link to the GitHub sponsorship page for
the user 'ryoppippi'.
