### PR TITLE
fix(package.json): pin typescript version to ~5.4.5

### DIFF
--- a/packages/unplugin-typia/package.json
+++ b/packages/unplugin-typia/package.json
@@ -88,7 +88,7 @@
 		"magic-string": "^0.30.10",
 		"mlly": "^1.7.1",
 		"pathe": "^1.1.2",
-		"typescript": "^5.4.5",
+		"typescript": "~5.4.5",
 		"unplugin": "^1.5.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
This commit changes the typescript dependency version from caret (^)
version to tilde (~) version. This ensures that only patch updates are
allowed, providing more stability to the project.
