### PR TITLE
feat: update permissions in release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   jsr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,11 +29,6 @@ jobs:
     needs:
       - jsr
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      id-token: write
-
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This commit moves the permissions block for contents read and id-token write
from the second job to the first job in the GitHub Actions workflow. This
change ensures that the permissions are set correctly for the workflow.
