### PR TITLE
feat(cache): replace readPackageJSON with direct import

### DIFF
--- a/packages/unplugin-typia/src/core/cache.ts
+++ b/packages/unplugin-typia/src/core/cache.ts
@@ -3,13 +3,11 @@ import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import process from 'node:process';
 import { basename, dirname, join } from 'pathe';
-import { readPackageJSON } from 'pkg-types';
+import { version as typiaVersion } from 'typia/package.json';
 import type { CacheKey, CachePath, Data, FilePath, ID, Source } from './types.js';
 import { wrap } from './types.js';
 import type { ResolvedOptions } from './options.js';
 import { isBun } from './utils.js';
-
-const typiaVersion: Readonly<string> | undefined = await readPackageJSON('typia').then(pkg => pkg.version);
 
 type ResolvedCacheOptions = ResolvedOptions['cache'];
 


### PR DESCRIPTION
The `readPackageJSON` function was used to get the version of 'typia'.
This has been replaced with a direct import from 'typia/package.json'.
This change simplifies the code and reduces the number of dependencies.
