### PR TITLE
feat(eslint): use cache for linting and formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ npm-debug.log
 # yarn
 yarn-error.log
 
+# eslint cache
+.eslintcache

--- a/packages/unplugin-typia/package.json
+++ b/packages/unplugin-typia/package.json
@@ -51,8 +51,8 @@
 		"dist"
 	],
 	"scripts": {
-		"lint": "npm run check && eslint .",
-		"format": "eslint --fix .",
+		"lint": "npm run check && eslint --cache .",
+		"format": "eslint --cache --fix .",
 		"test": "npm run check && bun test ./test/*.ts",
 		"check": "bun tsc --noEmit",
 		"publish": "bun x jsr publish"


### PR DESCRIPTION
This commit modifies the lint and format scripts in the package.json
file of the unplugin-typia package to use eslint's cache feature. This
improves performance by only linting files that have changed since the
last linting run.
