### PR TITLE
feat: bump version to 0.5.0

### DIFF
--- a/packages/unplugin-typia/jsr.json
+++ b/packages/unplugin-typia/jsr.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ryoppippi/unplugin-typia",
-	"version": "0.4.16",
+	"version": "0.5.0",
 	"exports": {
 		".": "./src/index.ts",
 		"./api": "./src/api.ts",


### PR DESCRIPTION
The version of the package "@ryoppippi/unplugin-typia" has been updated
from 0.4.16 to 0.5.0. This is a minor version update indicating new
features or significant changes.
