### PR TITLE
feat(cache.ts): import typia package.json with json type

### DIFF
--- a/packages/unplugin-typia/src/core/cache.ts
+++ b/packages/unplugin-typia/src/core/cache.ts
@@ -3,11 +3,13 @@ import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import process from 'node:process';
 import { basename, dirname, join } from 'pathe';
-import { version as typiaVersion } from 'typia/package.json';
+import typiaPackageJson from 'typia/package.json' with {type: 'json'};
 import type { CacheKey, CachePath, Data, FilePath, ID, Source } from './types.js';
 import { wrap } from './types.js';
 import type { ResolvedOptions } from './options.js';
 import { isBun } from './utils.js';
+
+const { version: typiaVersion } = typiaPackageJson;
 
 type ResolvedCacheOptions = ResolvedOptions['cache'];
 


### PR DESCRIPTION
The import statement for typia's package.json has been updated to use the json type. This change ensures that the version of typia is correctly extracted and used within the cache.ts file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved how the version information is imported from `typia/package.json`, enhancing maintainability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->