### PR TITLE
feat: Simplify cache configuration in UnpluginTypia

### DIFF
--- a/examples/esbuild/build.ts
+++ b/examples/esbuild/build.ts
@@ -14,9 +14,7 @@ await build({
   outfile: `${outDir}/main.mjs`,
   plugins: [UnpluginTypia({
     log: 'verbose',
-    cache: {
-      enable: false,
-    }
+    cache: false,
   })],
   format: 'esm'
 })

--- a/examples/sveltekit/vite.config.ts
+++ b/examples/sveltekit/vite.config.ts
@@ -7,9 +7,7 @@ export default defineConfig({
   plugins: [
     UnpluginTypia({
       log: "verbose",
-      cache: {
-        enable: true,
-      }
+      cache: false,
     }),
     sveltekit(),
   ],


### PR DESCRIPTION
This commit simplifies the cache configuration in UnpluginTypia by
changing the `cache` option from an object to a boolean. This change
affects both the esbuild and sveltekit examples. The `cache` option
now directly takes a boolean value to enable or disable caching.
