### PR TITLE
feat: Move log message to buildStart hook

### DIFF
--- a/packages/unplugin-typia/src/core/index.ts
+++ b/packages/unplugin-typia/src/core/index.ts
@@ -38,18 +38,20 @@ const unpluginFactory: UnpluginFactory<
 
 	const { cache: cacheOptions, log: logOption } = options;
 
-	if (logOption !== false) {
-		log(
-			'box',
-			cacheOptions ? `Cache enabled` : `Cache disabled`,
-		);
-	}
-
 	const showLog = logOption === 'verbose' && cacheOptions;
 
 	return {
 		name,
 		enforce: options.enforce,
+
+		buildStart() {
+			if (logOption !== false) {
+				log(
+					'box',
+					cacheOptions ? `Cache enabled` : `Cache disabled`,
+				);
+			}
+		},
 
 		transformInclude(id) {
 			return filter(id);


### PR DESCRIPTION
The log message indicating whether caching is enabled or disabled
has been moved to the buildStart hook. This change ensures that the
log message is displayed at the start of the build process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced plugin initialization with conditional build steps and logging.
- **Improvements**
  - Improved import structure for better type management.
  - Enhanced logging for build status based on configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->