### PR TITLE
Fix unexpected token with

### DIFF
--- a/packages/unplugin-typia/src/core/cache.ts
+++ b/packages/unplugin-typia/src/core/cache.ts
@@ -1,13 +1,13 @@
-import { accessSync, constants, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { createHash } from 'node:crypto';
-import { basename, dirname, join } from 'pathe';
-import findCacheDirectory from 'find-cache-dir';
-import typiaPackageJson from 'typia/package.json' with { type: 'json' };
-import type { CacheKey, CachePath, Data, FilePath, ID, Source } from './types.js';
-import { wrap } from './types.js';
-import { isBun } from './utils.js';
+import { accessSync, constants, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { basename, dirname, join } from 'pathe'
+import findCacheDirectory from 'find-cache-dir'
+import typiaPackageJson from 'typia/package.json' assert { type: 'json' }
+import type { CacheKey, CachePath, Data, FilePath, ID, Source } from './types.js'
+import { wrap } from './types.js'
+import { isBun } from './utils.js'
 
-const { version: typiaVersion } = typiaPackageJson;
+const { version: typiaVersion } = typiaPackageJson
 
 /**
  * Cache class
@@ -15,95 +15,94 @@ const { version: typiaVersion } = typiaPackageJson;
  * @caution: CacheOptions.enable is ignored
  */
 export class Cache {
-	#data: Data | undefined;
-	#hashKey: CacheKey;
-	#hashPath: CachePath;
+  #data: Data | undefined
+  #hashKey: CacheKey
+  #hashPath: CachePath
 
-	constructor(id: ID, source: Source) {
-		this.#hashKey = this.getHashKey(id, source);
-		this.#hashPath = wrap<CachePath>(join(getCacheDir(), this.#hashKey));
-		this.#data = this.getCache();
-	}
+  constructor(id: ID, source: Source) {
+    this.#hashKey = this.getHashKey(id, source)
+    this.#hashPath = wrap<CachePath>(join(getCacheDir(), this.#hashKey))
+    this.#data = this.getCache()
+  }
 
-	[Symbol.dispose]() {
-		this.setCache();
-	}
+  [Symbol.dispose]() {
+    this.setCache()
+  }
 
-	/**
-	 * Get cache data
-	 */
-	get data() {
-		return this.#data;
-	}
+  /**
+   * Get cache data
+   */
+  get data() {
+    return this.#data
+  }
 
-	/**
-	 * Set cache data
-	 */
-	set data(value: Data | undefined) {
-		this.#data = value;
-	}
+  /**
+   * Set cache data
+   */
+  set data(value: Data | undefined) {
+    this.#data = value
+  }
 
-	private getCache() {
-		if (!(existsSync(this.#hashPath))) {
-			return undefined;
-		}
+  private getCache() {
+    if (!existsSync(this.#hashPath)) {
+      return undefined
+    }
 
-		const data = readFileSync(this.#hashPath, { encoding: 'utf8' });
+    const data = readFileSync(this.#hashPath, { encoding: 'utf8' })
 
-		/* if data does not end with hashComment, the cache is invalid */
-		if (!data.endsWith(this.hashComment)) {
-			return undefined;
-		}
+    /* if data does not end with hashComment, the cache is invalid */
+    if (!data.endsWith(this.hashComment)) {
+      return undefined
+    }
 
-		return wrap<Data>(data);
-	}
+    return wrap<Data>(data)
+  }
 
-	private setCache() {
-		const cacheDir = dirname(this.#hashPath);
-		if (this.#data == null && existsSync(this.#hashPath)) {
-			rmSync(this.#hashPath);
-			return;
-		}
+  private setCache() {
+    const cacheDir = dirname(this.#hashPath)
+    if (this.#data == null && existsSync(this.#hashPath)) {
+      rmSync(this.#hashPath)
+      return
+    }
 
-		if (!existsSync(cacheDir)) {
-			mkdirSync(cacheDir, { recursive: true });
-		}
+    if (!existsSync(cacheDir)) {
+      mkdirSync(cacheDir, { recursive: true })
+    }
 
-		if (!this.isWritable(cacheDir)) {
-			throw new Error('Cache directory is not writable.');
-		}
+    if (!this.isWritable(cacheDir)) {
+      throw new Error('Cache directory is not writable.')
+    }
 
-		const cache = this.#data + this.hashComment;
-		writeFileSync(this.#hashPath, cache, { encoding: 'utf8' });
-	}
+    const cache = this.#data + this.hashComment
+    writeFileSync(this.#hashPath, cache, { encoding: 'utf8' })
+  }
 
-	private getHashKey(id: ID, source: Source): CacheKey {
-		const h = this.hash(source);
-		const filebase = `${basename(dirname(id))}_${basename(id)}`;
+  private getHashKey(id: ID, source: Source): CacheKey {
+    const h = this.hash(source)
+    const filebase = `${basename(dirname(id))}_${basename(id)}`
 
-		return wrap<CacheKey>(`${filebase}_${h}`);
-	}
+    return wrap<CacheKey>(`${filebase}_${h}`)
+  }
 
-	private hash(input: string): string {
-		if (isBun()) {
-			return Bun.hash(input).toString();
-		}
-		return createHash('md5').update(input).digest('hex');
-	}
+  private hash(input: string): string {
+    if (isBun()) {
+      return Bun.hash(input).toString()
+    }
+    return createHash('md5').update(input).digest('hex')
+  }
 
-	private get hashComment() {
-		return `/* unplugin-typia-${typiaVersion ?? ''}-${this.#hashKey} */`;
-	}
+  private get hashComment() {
+    return `/* unplugin-typia-${typiaVersion ?? ''}-${this.#hashKey} */`
+  }
 
-	private isWritable(filename: string): boolean {
-		try {
-			accessSync(filename, constants.W_OK);
-			return true;
-		}
-		catch {
-			return false;
-		}
-	}
+  private isWritable(filename: string): boolean {
+    try {
+      accessSync(filename, constants.W_OK)
+      return true
+    } catch {
+      return false
+    }
+  }
 }
 
 /**
@@ -111,11 +110,11 @@ export class Cache {
  * copy from https://github.com/unjs/jiti/blob/690b727d7c0c0fa721b80f8085cafe640c6c2a40/src/cache.ts
  */
 function getCacheDir(): FilePath {
-	const cacheDir = findCacheDirectory({ name: 'unplugin_typia', create: true });
+  const cacheDir = findCacheDirectory({ name: 'unplugin_typia', create: true })
 
-	if (cacheDir == null) {
-		throw new Error('Cache directory is not found.');
-	}
+  if (cacheDir == null) {
+    throw new Error('Cache directory is not found.')
+  }
 
-	return wrap<FilePath>(cacheDir);
+  return wrap<FilePath>(cacheDir)
 }

--- a/packages/unplugin-typia/src/core/cache.ts
+++ b/packages/unplugin-typia/src/core/cache.ts
@@ -2,7 +2,7 @@ import { accessSync, constants, existsSync, mkdirSync, readFileSync, rmSync, wri
 import { createHash } from 'node:crypto';
 import { basename, dirname, join } from 'pathe';
 import findCacheDirectory from 'find-cache-dir';
-import typiaPackageJson from 'typia/package.json' with { type: 'json' };
+import typiaPackageJson from 'typia/package.json' assert { type: 'json' };
 import type { CacheKey, CachePath, Data, FilePath, ID, Source } from './types.js';
 import { wrap } from './types.js';
 import { isBun } from './utils.js';

--- a/packages/unplugin-typia/src/core/cache.ts
+++ b/packages/unplugin-typia/src/core/cache.ts
@@ -1,13 +1,13 @@
-import { accessSync, constants, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { createHash } from 'node:crypto'
-import { basename, dirname, join } from 'pathe'
-import findCacheDirectory from 'find-cache-dir'
-import typiaPackageJson from 'typia/package.json' assert { type: 'json' }
-import type { CacheKey, CachePath, Data, FilePath, ID, Source } from './types.js'
-import { wrap } from './types.js'
-import { isBun } from './utils.js'
+import { accessSync, constants, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { basename, dirname, join } from 'pathe';
+import findCacheDirectory from 'find-cache-dir';
+import typiaPackageJson from 'typia/package.json' with { type: 'json' };
+import type { CacheKey, CachePath, Data, FilePath, ID, Source } from './types.js';
+import { wrap } from './types.js';
+import { isBun } from './utils.js';
 
-const { version: typiaVersion } = typiaPackageJson
+const { version: typiaVersion } = typiaPackageJson;
 
 /**
  * Cache class
@@ -15,94 +15,95 @@ const { version: typiaVersion } = typiaPackageJson
  * @caution: CacheOptions.enable is ignored
  */
 export class Cache {
-  #data: Data | undefined
-  #hashKey: CacheKey
-  #hashPath: CachePath
+	#data: Data | undefined;
+	#hashKey: CacheKey;
+	#hashPath: CachePath;
 
-  constructor(id: ID, source: Source) {
-    this.#hashKey = this.getHashKey(id, source)
-    this.#hashPath = wrap<CachePath>(join(getCacheDir(), this.#hashKey))
-    this.#data = this.getCache()
-  }
+	constructor(id: ID, source: Source) {
+		this.#hashKey = this.getHashKey(id, source);
+		this.#hashPath = wrap<CachePath>(join(getCacheDir(), this.#hashKey));
+		this.#data = this.getCache();
+	}
 
-  [Symbol.dispose]() {
-    this.setCache()
-  }
+	[Symbol.dispose]() {
+		this.setCache();
+	}
 
-  /**
-   * Get cache data
-   */
-  get data() {
-    return this.#data
-  }
+	/**
+	 * Get cache data
+	 */
+	get data() {
+		return this.#data;
+	}
 
-  /**
-   * Set cache data
-   */
-  set data(value: Data | undefined) {
-    this.#data = value
-  }
+	/**
+	 * Set cache data
+	 */
+	set data(value: Data | undefined) {
+		this.#data = value;
+	}
 
-  private getCache() {
-    if (!existsSync(this.#hashPath)) {
-      return undefined
-    }
+	private getCache() {
+		if (!(existsSync(this.#hashPath))) {
+			return undefined;
+		}
 
-    const data = readFileSync(this.#hashPath, { encoding: 'utf8' })
+		const data = readFileSync(this.#hashPath, { encoding: 'utf8' });
 
-    /* if data does not end with hashComment, the cache is invalid */
-    if (!data.endsWith(this.hashComment)) {
-      return undefined
-    }
+		/* if data does not end with hashComment, the cache is invalid */
+		if (!data.endsWith(this.hashComment)) {
+			return undefined;
+		}
 
-    return wrap<Data>(data)
-  }
+		return wrap<Data>(data);
+	}
 
-  private setCache() {
-    const cacheDir = dirname(this.#hashPath)
-    if (this.#data == null && existsSync(this.#hashPath)) {
-      rmSync(this.#hashPath)
-      return
-    }
+	private setCache() {
+		const cacheDir = dirname(this.#hashPath);
+		if (this.#data == null && existsSync(this.#hashPath)) {
+			rmSync(this.#hashPath);
+			return;
+		}
 
-    if (!existsSync(cacheDir)) {
-      mkdirSync(cacheDir, { recursive: true })
-    }
+		if (!existsSync(cacheDir)) {
+			mkdirSync(cacheDir, { recursive: true });
+		}
 
-    if (!this.isWritable(cacheDir)) {
-      throw new Error('Cache directory is not writable.')
-    }
+		if (!this.isWritable(cacheDir)) {
+			throw new Error('Cache directory is not writable.');
+		}
 
-    const cache = this.#data + this.hashComment
-    writeFileSync(this.#hashPath, cache, { encoding: 'utf8' })
-  }
+		const cache = this.#data + this.hashComment;
+		writeFileSync(this.#hashPath, cache, { encoding: 'utf8' });
+	}
 
-  private getHashKey(id: ID, source: Source): CacheKey {
-    const h = this.hash(source)
-    const filebase = `${basename(dirname(id))}_${basename(id)}`
+	private getHashKey(id: ID, source: Source): CacheKey {
+		const h = this.hash(source);
+		const filebase = `${basename(dirname(id))}_${basename(id)}`;
 
-    return wrap<CacheKey>(`${filebase}_${h}`)
-  }
+		return wrap<CacheKey>(`${filebase}_${h}`);
+	}
 
-  private hash(input: string): string {
-    if (isBun()) {
-      return Bun.hash(input).toString()
-    }
-    return createHash('md5').update(input).digest('hex')
-  }
+	private hash(input: string): string {
+		if (isBun()) {
+			return Bun.hash(input).toString();
+		}
+		return createHash('md5').update(input).digest('hex');
+	}
 
-  private get hashComment() {
-    return `/* unplugin-typia-${typiaVersion ?? ''}-${this.#hashKey} */`
-  }
+	private get hashComment() {
+		return `/* unplugin-typia-${typiaVersion ?? ''}-${this.#hashKey} */`;
+	}
 
-  private isWritable(filename: string): boolean {
-    try {
-      accessSync(filename, constants.W_OK)
-      return true
-    } catch {
-      return false
-    }
-  }
+	private isWritable(filename: string): boolean {
+		try {
+			accessSync(filename, constants.W_OK);
+			return true;
+		}
+		catch {
+			return false;
+		}
+	}
 }
 
 /**
@@ -110,11 +111,11 @@ export class Cache {
  * copy from https://github.com/unjs/jiti/blob/690b727d7c0c0fa721b80f8085cafe640c6c2a40/src/cache.ts
  */
 function getCacheDir(): FilePath {
-  const cacheDir = findCacheDirectory({ name: 'unplugin_typia', create: true })
+	const cacheDir = findCacheDirectory({ name: 'unplugin_typia', create: true });
 
-  if (cacheDir == null) {
-    throw new Error('Cache directory is not found.')
-  }
+	if (cacheDir == null) {
+		throw new Error('Cache directory is not found.');
+	}
 
-  return wrap<FilePath>(cacheDir)
+	return wrap<FilePath>(cacheDir);
 }


### PR DESCRIPTION
Found the following issue when using it in a Svelte project. Fixed by changing with to assert.

```
Unexpected token 'with' svelte(style)
```
<img width="286" alt="image" src="https://github.com/user-attachments/assets/3786e544-0a19-4813-a79f-1524ef644c9f">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated import statement handling in the core module of the `unplugin-typia` package to improve compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->