### PR TITLE
refactor(core/svelte): dependency resolution

### DIFF
--- a/packages/unplugin-typia/package.json
+++ b/packages/unplugin-typia/package.json
@@ -77,6 +77,9 @@
 		"rollup": {
 			"optional": true
 		},
+		"svelte": {
+			"optional": true
+		},
 		"vite": {
 			"optional": true
 		},

--- a/packages/unplugin-typia/src/core/languages/svelte.ts
+++ b/packages/unplugin-typia/src/core/languages/svelte.ts
@@ -1,4 +1,3 @@
-import { preprocess as sveltePreprocess } from 'svelte/compiler';
 import type { Data, ID, Source } from '../types.js';
 import { wrap } from '../types.js';
 
@@ -24,6 +23,7 @@ export async function preprocess(
 	{ source, id, transform }:
 	{ source: Source; id: ID; transform: TransformFunction },
 ): Promise<{ code: Data }> {
+	const { preprocess: sveltePreprocess } = await import('svelte/compiler');
 	const { code } = await sveltePreprocess(source, {
 		script: async ({ content, filename, attributes }) => {
 			if (filename == null) {


### PR DESCRIPTION
The Svelte dependency version has been updated from 'next' to '^5.0.0-next.183'. This change has been reflected in both the bun.lockb and package.json files. The Svelte dependency has also been moved from 'peerDependencies' to 'devDependencies' in the package.json file.