### PR TITLE
refactor: remove redundant code comparison

### DIFF
--- a/packages/unplugin-typia/src/core/index.ts
+++ b/packages/unplugin-typia/src/core/index.ts
@@ -138,11 +138,6 @@ const unpluginFactory: UnpluginFactory<
 				return;
 			}
 
-			/** skip if source is same as code */
-			if (unwrap(source) === unwrap(code)) {
-				return;
-			}
-
 			return generateCodeWithMap({ source, code, id });
 		},
 	};


### PR DESCRIPTION
The comparison between the source and the code was removed from the
unpluginFactory function. This comparison was deemed unnecessary as it
was causing the function to exit prematurely in cases where the source
and code were identical, which is not always an undesired scenario.
