### PR TITLE
feat(utils.ts): add dynamicImport utility function (fixes: fixes: #198)

### DIFF
--- a/packages/unplugin-typia/src/core/languages/svelte.ts
+++ b/packages/unplugin-typia/src/core/languages/svelte.ts
@@ -1,5 +1,6 @@
 import type { Data, ID, Source } from '../types.js';
 import { wrap } from '../types.js';
+import { dynamicImport } from '../utils.js';
 
 /**
  * Check if a file is a Svelte file.
@@ -23,7 +24,7 @@ export async function preprocess(
 	{ source, id, transform }:
 	{ source: Source; id: ID; transform: TransformFunction },
 ): Promise<{ code: Data }> {
-	const { preprocess: sveltePreprocess } = await import('svelte/compiler');
+	const { preprocess: sveltePreprocess } = await dynamicImport('svelte/compiler') as typeof import('svelte/compiler');
 	const { code } = await sveltePreprocess(source, {
 		script: async ({ content, filename, attributes }) => {
 			if (filename == null) {

--- a/packages/unplugin-typia/src/core/utils.ts
+++ b/packages/unplugin-typia/src/core/utils.ts
@@ -10,3 +10,11 @@ export function log(
 export function isBun() {
 	return globalThis.Bun != null;
 }
+
+/**
+ * Dynamic import a module.
+ * Because JSR fails to resolve dynamic import, we have to use this workaround. (see: https://github.com/ryoppippi/unplugin-typia/issues/198)
+ */
+export async function dynamicImport<T extends string>(specifier: T): Promise<unknown> {
+	return import(specifier);
+}


### PR DESCRIPTION
This commit introduces a new utility function, dynamicImport, which is used to dynamically import modules. This function is now used in the Svelte language file to import the Svelte compiler. This change improves the code readability and maintainability.