### PR TITLE
feat(svelte): append .ts to id instead of replacing .svelte

### DIFF
--- a/packages/unplugin-typia/src/core/languages/svelte.ts
+++ b/packages/unplugin-typia/src/core/languages/svelte.ts
@@ -38,7 +38,7 @@ export async function preprocess(
 			const id = wrap<ID>(filename);
 			const source = wrap<Source>(content);
 
-			const tsID = wrap<ID>(id.replace(/\.svelte$/, '.ts'));
+			const tsID = wrap<ID>(`${id}.ts`);
 
 			const { code } = await transform({ source, id: tsID });
 


### PR DESCRIPTION
This change modifies the way TypeScript identifiers are generated for Svelte files. Instead of replacing the .svelte extension with .ts, it now appends .ts to the existing filename.
This prevents conflicts with SvelteKit files like +page.ts & +page.svelte

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling of Svelte file IDs, ensuring correct transformation to TypeScript files.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->