### PR TITLE
fix(cache): use `createRequire` to dynamically import `package.json`

### DIFF
--- a/packages/unplugin-typia/src/core/cache.ts
+++ b/packages/unplugin-typia/src/core/cache.ts
@@ -1,13 +1,14 @@
 import { accessSync, constants, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
 import { basename, dirname, join } from 'pathe';
 import findCacheDirectory from 'find-cache-dir';
-import typiaPackageJson from 'typia/package.json' with { type: 'json' };
 import type { CacheKey, CachePath, Data, FilePath, ID, Source } from './types.js';
 import { wrap } from './types.js';
 import { isBun } from './utils.js';
 
-const { version: typiaVersion } = typiaPackageJson;
+/** get typia version */
+const { version: typiaVersion } = createRequire(import.meta.url)('typia/package.json') as typeof import('typia/package.json');
 
 /**
  * Cache class


### PR DESCRIPTION
fixes: #212 #194

The previous static import of typia's package.json was replaced with a dynamic import using createRequire. This change allows for more flexibility and compatibility with different module systems.