### PR TITLE
refactor(core): use -1 as end parameter for MagicString

### DIFF
--- a/packages/unplugin-typia/src/core/index.ts
+++ b/packages/unplugin-typia/src/core/index.ts
@@ -45,7 +45,7 @@ const unpluginFactory: UnpluginFactory<
 	function generateCodeWithMap({ source, code, id }: { source: Source; code: Data; id: ID }) {
 		/** generate Magic string */
 		const s = new MagicString(source);
-		s.overwrite(0, source.length, code);
+		s.overwrite(0, -1, code);
 
 		if (!s.hasChanged()) {
 			return;


### PR DESCRIPTION
The MagicString overwrite method was previously using the source length as the end parameter. This has been adjusted to use -1, which represents the end of the string. This ensures that the overwrite operation correctly replaces the entire source string.