### PR TITLE
fix: `resolve` id (fix #237)

### DIFF
--- a/packages/unplugin-typia/src/core/index.ts
+++ b/packages/unplugin-typia/src/core/index.ts
@@ -2,6 +2,7 @@ import type { UnpluginFactory, UnpluginInstance } from 'unplugin';
 import { createUnplugin } from 'unplugin';
 import { createFilter as rollupCreateFilter } from '@rollup/pluginutils';
 import MagicString from 'magic-string';
+import { resolve } from 'pathe';
 
 import type { ResolvedOptions } from './options.ts';
 import type { Options } from './options.js';
@@ -123,7 +124,7 @@ const unpluginFactory: UnpluginFactory<
 
 		async transform(_source, _id) {
 			const source = wrap<Source>(_source);
-			const id = wrap<ID>(_id);
+			const id = wrap<ID>(resolve(_id));
 
 			/** skip if source does not include typia */
 			if (!source.includes('typia')) {

--- a/packages/unplugin-typia/src/core/typia.ts
+++ b/packages/unplugin-typia/src/core/typia.ts
@@ -179,8 +179,7 @@ function transform(
 		},
 	);
 
-	const resolvedId = resolve(id);
-	const file = transformationResult.transformed.find(t => resolve(t.fileName) === resolvedId);
+	const file = transformationResult.transformed.find(t => resolve(t.fileName) === id);
 
 	if (file == null) {
 		throw new Error('No file found');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of identifiers to ensure absolute path resolution, enhancing plugin functionality and robustness.
	- Refined logic in the file identification process to streamline the transformation process, potentially improving accuracy in file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->