### PR TITLE
feat: Add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,52 @@
+name: 🐞 Bug report
+description: Report an issue with unplugin-typia
+labels: [pending triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! If you have a usage question
+        or are unsure if this is really a bug, make sure to:
+        - Read the `README.md` of using the package
+        - Search related issues and discussions in the repository
+
+  - type: input
+    id: version
+    attributes:
+      label: unplugin-typia version
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: What platform is your computer?
+      description: |
+        For MacOS and Linux: copy the output of `uname -mprs`
+        For Windows: copy the output of `"$([Environment]::OSVersion | ForEach-Object VersionString) $(if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "x86" })"` in the PowerShell console
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a link to a GitHub repo that can reproduce the problem you ran into. The GitHub repo should contain GitHub Action to reproduce the error. A [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) is required unless you are absolutely sure that the issue is obvious and the provided information is enough to understand the problem. [Why reproduction is required](https://antfu.me/posts/why-reproductions-are-required).
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Validations
+      description: Before submitting the issue, please make sure you do the following
+      options:
+        - label: Check that there isn't [already an issue](https://github.com/ryoppippi/unplugin-typia/issues) that reports the same bug to avoid creating a duplicate.
+          required: true
+        - label: Check that this is a concrete bug.
+          required: true
+        - label: The provided reproduction is a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) of the bug.
+          required: true


### PR DESCRIPTION
This commit introduces a new bug report issue template for the unplugin-typia repository. The template includes fields for version, platform, bug description, reproduction steps, and some checkboxes for validations. This will help in standardizing the bug reporting process and ensure all necessary information is provided.