### PR TITLE
fix: the way to detect warn function is available

### DIFF
--- a/packages/unplugin-typia/src/core/typia.ts
+++ b/packages/unplugin-typia/src/core/typia.ts
@@ -206,10 +206,14 @@ function warnDiagnostic(
 	unpluginContext: UnContext,
 ) {
 	for (const diagnostic of diagnostics) {
-		const warn = unpluginContext?.warn ?? consola.warn;
-		warn(
-			transformed.map(e => e.fileName).join(','),
-		);
+		const warn = ((message) => {
+			if (unpluginContext?.warn != null) {
+				return unpluginContext.warn(message);
+			}
+			return consola.warn(message);
+		}) satisfies typeof unpluginContext.warn;
+
+		warn(transformed.map(e => e.fileName).join(','));
 		warn(JSON.stringify(diagnostic.messageText));
 	}
 }


### PR DESCRIPTION
This commit refactors the warning message handling in the typia.ts file.

related: #269 
