### PR TITLE
fix: tsconfig path resolution

### DIFF
--- a/packages/unplugin-typia/src/core/typia.ts
+++ b/packages/unplugin-typia/src/core/typia.ts
@@ -65,7 +65,7 @@ export async function transformTypia(
 async function getTsCompilerOption(cacheEnable = true, tsconfigId?: string): Promise<ts.CompilerOptions> {
 	const parseTsComilerOptions = async () => {
 		const readFile = (path: string) => ts.sys.readFile(path);
-		const id = await resolveTSConfig(tsconfigId);
+		const id = (tsconfigId != null) ? resolve(tsconfigId) : await resolveTSConfig();
 
 		const tsconfigParseResult = ts.readConfigFile(id, readFile);
 		if (tsconfigParseResult.error != null) {


### PR DESCRIPTION
This change modifies the `getTsCompilerOption` function to directly resolve
the path of a provided `tsconfigId`. If no `tsconfigId` is provided, it
falls back to the `resolveTSConfig` function. This provides more flexibility
in tsconfig resolution.

Related : #269 