### PR TITLE
feat: update README and webpack plugin usage notes

### DIFF
--- a/packages/unplugin-typia/README.md
+++ b/packages/unplugin-typia/README.md
@@ -189,7 +189,11 @@ Examples:
 
 <details>
 <summary>Webpack</summary><br>
-> ⚠️ Note: Currently, this plugin works only with 'esm' target. If you want to use 'cjs' target, please use with [`jiti`](https://github.com/unjs/jiti). Refer [this issue](https://github.com/samchon/typia/issues/1094).
+
+> ⚠️ Note: Currently, this plugin works only with 'esm' target.
+> If you want to use 'cjs' target on Node < 20.17.0 , please use with [`jiti`](https://github.com/unjs/jiti).
+> If you want to use 'cjs' target on Node >= 20.17.0, please use with `require` and enable [`--experimental-require-modules` flag](https://github.com/nodejs/node/pull/51977).
+> If you want to use 'esm' target, don't worry! You can use this plugin without any additional setup.
 
 ```sh
 npm install jiti
@@ -197,8 +201,13 @@ npm install jiti
 
 ```js
 // webpack.config.js
+
+// if you use Node < 20.17.0
 const jiti = require('jiti')(__filename);
 const { default: UnpluginTypia } = jiti('@ryoppippi/unplugin-typia/webpack');
+
+// if you use Node >= 20.17.0
+// const { default: UnpluginTypia } = require("@ryoppippi/unplugin-typia/webpack");
 
 module.exports = {
 	plugins: [

--- a/packages/unplugin-typia/src/webpack.ts
+++ b/packages/unplugin-typia/src/webpack.ts
@@ -9,15 +9,23 @@ import unplugin from './core/index.js';
 /**
  * Webpack plugin
  *
- * Currently, this plugin works only with 'esm' target. If you want to use 'cjs' target, please use with [`jiti`](https://github.com/unjs/jiti).
+ * Currently, this plugin works only with 'esm' target.
+ * If you want to use 'cjs' target on Node < 20.17.0 , please use with [`jiti`](https://github.com/unjs/jiti).
+ * If you want to use 'cjs' target on Node >= 20.17.0, please use with `require` and enable [`--experimental-require-modules` flag](https://github.com/nodejs/node/pull/51977).
+ * If you want to use 'esm' target, don't worry! You can use this plugin without any additional setup.
  *
  * Refer this issue https://github.com/samchon/typia/issues/1094
  *
  * @example
  * ```js
  * // webpack.config.js
+ *
+ * // if you use Node < 20.17.0
  * const jiti = require("jiti")(__filename);
  * const { default: UnpluginTypia } = jiti("@ryoppippi/unplugin-typia/webpack");
+ *
+ * // if you use Node >= 20.17.0
+ * const { default: UnpluginTypia } = require("@ryoppippi/unplugin-typia/webpack");
  *
  * module.exports = {
  *  plugins: [UnpluginTypia({ /* your config *\/ })],


### PR DESCRIPTION
Updated the README and webpack plugin usage notes to provide clearer instructions for using the plugin with different Node.js versions. Added specific instructions for Node < 20.17.0 and Node >= 20.17.0, including the use of `jiti` and the `--experimental-require-modules` flag.