### PR TITLE
Add newline after hash comment in cache

### DIFF
--- a/packages/unplugin-typia/src/core/cache.ts
+++ b/packages/unplugin-typia/src/core/cache.ts
@@ -100,7 +100,7 @@ export class Cache {
 	}
 
 	private get hashComment() {
-		return `/* unplugin-typia-${typiaVersion ?? ''}-${this.#hashKey} */`;
+		return `/* unplugin-typia-${typiaVersion ?? ''}-${this.#hashKey} */\n`;
 	}
 
 	private isWritable(filename: string): boolean {

--- a/packages/unplugin-typia/tests/cache.spec.ts
+++ b/packages/unplugin-typia/tests/cache.spec.ts
@@ -14,7 +14,7 @@ function removeComments(data: string | undefined) {
 	}
 
 	// eslint-disable-next-line regexp/no-unused-capturing-group
-	return data.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, '');
+	return data.replace(/\/\*[\s\S]*?\*\/\n?|([^\\:]|^)\/\/.*$/gm, '');
 }
 
 it('return null if cache is not found', async () => {


### PR DESCRIPTION
Fixes #353.

This change fixes my issue. Sorry for I can't provide reproduction. Feel free to close, but really helpful for me if you could merge this. Thank you.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated comment formatting in the cache system to ensure comments end with a newline.
	- Improved comment removal logic in tests to handle block comments followed by a newline.

- **Tests**
	- Verified caching functionality remains consistent with previous implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->