### PR TITLE
add tsconfig path to example for Vite plugin configuration

### DIFF
--- a/packages/unplugin-typia/README.md
+++ b/packages/unplugin-typia/README.md
@@ -54,7 +54,7 @@ import UnpluginTypia from '@ryoppippi/unplugin-typia/vite';
 
 export default defineConfig({
 	plugins: [
-		UnpluginTypia({ /* options */ }), // should be placed before other plugins like `react`, `svetle`, etc.
+		UnpluginTypia({ tsconfig: "./tsconfig.app.json" /* options */ }), // should be placed before other plugins like `react`, `svetle`, etc.
 	],
 });
 ```


### PR DESCRIPTION
Updated the Vite plugin documentation to specify that `tsconfig: "./tsconfig.app.json"` must be provided to ensure TypeScript's strict mode is enabled. The latest version of Vite does not enable strict mode in `tsconfig.json` by default but instead defines it in `tsconfig.app.json`, which is required for Typia to function correctly.

Fixes #393 