### PR TITLE
Major update from `typia`

### DIFF
--- a/packages/unplugin-typia/package.json
+++ b/packages/unplugin-typia/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@ryoppippi/unplugin-typia",
 	"type": "module",
-	"version": "1.2.1",
+	"version": "2.0.0",
 	"private": true,
 	"description": "unplugin for typia",
 	"author": "ryoppippi",
@@ -49,8 +49,6 @@
 		"pathe": "^1.1.2",
 		"pkg-types": "^1.2.1",
 		"type-fest": "^4.30.0",
-		"typescript": "~5.6.3",
-		"typia": "^7.6.3",
 		"unplugin": "^1.16.1"
 	},
 	"devDependencies": {
@@ -68,8 +66,13 @@
 		"eslint-plugin-format": "^0.1.3",
 		"rollup": "^4.28.0",
 		"ts-patch": "^3.2.1",
+		"typescript": "~5.8.2",
+		"typia": "^8.0.0",
 		"vite": "^6.0.2",
 		"vitest": "^2.1.8"
+	},
+	"peerDependencies": {
+		"typia": ">=8.0.0 <9.0.0"
 	},
 	"access": "public"
 }

--- a/packages/unplugin-typia/package.json
+++ b/packages/unplugin-typia/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@ryoppippi/unplugin-typia",
 	"type": "module",
-	"version": "2.0.0",
+	"version": "1.2.1",
 	"private": true,
 	"description": "unplugin for typia",
 	"author": "ryoppippi",


### PR DESCRIPTION
`typia` has released new major update `v8.0.0`.

I've tried to use `unplugin-typia` in `vite` environment, but it has been compiled by `v7.6.x` of `typia`.

Looking at `unplugin-typia`, it has defined `typia` as `dependencies`, so that caused such blackbox rolling back effect. To avoid this problem, it would better to define `typia` to the `peerDependencies`. Also, as `typia` is restricting `typescript` by its own `peerDependencies`, no need to restrict in `unplugin-typia`.

Therefore, defined `typia` in `peerDependencies`, and installed both `typia` and `typescript` in here repo by `devDependencies`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the package version to 2.0.0.
	- Removed some direct dependency constraints.
	- Upgraded development dependencies for improved compatibility.
	- Introduced a peer dependency requirement with a defined version range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->