### PR TITLE
fix(package.json): peer deps

### DIFF
--- a/packages/unplugin-typia/package.json
+++ b/packages/unplugin-typia/package.json
@@ -78,7 +78,18 @@
 		"prepublishOnly": "bun run build"
 	},
 	"peerDependencies": {
-		"typia": ">=8.0.0 <9.0.0"
+		"svelte": "^5.0.0",
+		"typescript": ">=4.8.0 <5.9.0",
+		"typia": ">=8.0.0 <9.0.0",
+		"vite": ">=3.0.0"
+	},
+	"peerDependenciesMeta": {
+		"svelte": {
+			"optional": true
+		},
+		"vite": {
+			"optional": true
+		}
 	},
 	"dependencies": {
 		"@rollup/pluginutils": "^5.1.4",


### PR DESCRIPTION
This pull request includes an update to the `packages/unplugin-typia/package.json` file to enhance the package's compatibility and flexibility with additional peer dependencies and metadata.

### Updates to `package.json`:

* Added `svelte` and `vite` as optional peer dependencies to support broader usage with these frameworks.
* Included `typescript` as a peer dependency to specify the compatible version range, ensuring proper TypeScript integration.
* Introduced `peerDependenciesMeta` to mark `svelte` and `vite` as optional, allowing users to choose whether to include these dependencies.