### PR TITLE
fix build

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -122,7 +122,7 @@
     },
     "packages/unplugin-typia": {
       "name": "@ryoppippi/unplugin-typia",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dependencies": {
         "@rollup/pluginutils": "^5.1.4",
         "consola": "^3.4.0",
@@ -746,7 +746,7 @@
 
     "@types/bonjour": ["@types/bonjour@3.5.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ=="],
 
-    "@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
+    "@types/bun": ["@types/bun@1.2.5", "", { "dependencies": { "bun-types": "1.2.5" } }, "sha512-w2OZTzrZTVtbnJew1pdFmgV99H0/L+Pvw+z1P67HaR18MHOzYnTYOi6qzErhK8HyT+DB782ADVPPE92Xu2/Opg=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -1058,7 +1058,7 @@
 
     "bumpp": ["bumpp@10.0.3", "", { "dependencies": { "args-tokenizer": "^0.3.0", "c12": "^2.0.1", "cac": "^6.7.14", "escalade": "^3.2.0", "js-yaml": "^4.1.0", "jsonc-parser": "^3.3.1", "package-manager-detector": "^0.2.9", "prompts": "^2.4.2", "semver": "^7.7.1", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.10" }, "bin": { "bumpp": "bin/bumpp.mjs" } }, "sha512-5ONBZenNf9yfTIl2vFvDEfeeioidt0fG10SzjHQw50BRxOmXzsdY+lab1+SDMfiW6UyJ1xQqzFymcy5wa8YhTA=="],
 
-    "bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
+    "bun-types": ["bun-types@1.2.5", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-3oO6LVGGRRKI4kHINx5PIdIgnLRb7l/SprhzqXapmoYkFl5m4j6EvALvbDVuuBFaamB46Ap6HCUxIXNLCGy+tg=="],
 
     "bunbuild": ["bunbuild@workspace:examples/bun-build"],
 

--- a/packages/unplugin-typia/tsup.config.ts
+++ b/packages/unplugin-typia/tsup.config.ts
@@ -7,6 +7,7 @@ export default <Options>{
 	],
 	clean: true,
 	format: ['esm'],
+	target: 'es2020',
 	dts: true,
 	cjsInterop: true,
 	splitting: true,


### PR DESCRIPTION
This pull request includes a change to the `packages/unplugin-typia/tsup.config.ts` file to update the target JavaScript version for the build process.

Build configuration update:

* [`packages/unplugin-typia/tsup.config.ts`](diffhunk://#diff-12d4cee330efbf0efcb7eefef905a7b469db4ea62852c5221809425be446f3c1R10): Added the `target` property with the value `es2020` to the export options


fixes: #402 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build configuration to target ES2020, ensuring that the output is optimised for modern JavaScript environments. This update leverages newer language features for improved compatibility and performance across contemporary platforms, ultimately delivering a smoother experience. Users may benefit from enhanced runtime performance and more efficient execution in supported systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->