### PR TITLE
ix: handle rslib entry query parameters in file paths

### DIFF
--- a/packages/unplugin-typia/src/core/index.ts
+++ b/packages/unplugin-typia/src/core/index.ts
@@ -176,6 +176,9 @@ const unpluginFactory: UnpluginFactory<
 		},
 
 		transformInclude(id) {
+			if (id.endsWith('?__rslib_entry__')) {
+				id.replace('?__rslib_entry__', '');
+			}
 			return filter(id);
 		},
 


### PR DESCRIPTION
Add ufo dependency to properly parse filenames in the transformInclude hook, helping to ensure that filter functions work consistently with path identifiers across different environments.
fixes(#417)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - We have optimised the way file references are handled, offering a more accurate and reliable filtering process. This change ensures that only the appropriate resources are processed, leading to a smoother overall experience.

- **Chores**
  - A new underlying dependency was introduced to support these enhancements. This integration bolsters performance, improves stability, and aligns with our commitment to continuous optimisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->