### PR TITLE
fix: '\n' should not be ignore firstNonWhitespaceIndexOfText logic

### DIFF
--- a/packages/unplugin-typia/src/core/index.ts
+++ b/packages/unplugin-typia/src/core/index.ts
@@ -92,7 +92,7 @@ const unpluginFactory: UnpluginFactory<
 					 * get first non-whitespace character of text (maybe bug of magic-string)
 					 * text.search(/\S/) ignore `\n`, but it is important (https://github.com/ryoppippi/unplugin-typia/issues/434)
 					 */
-					const firstNonWhitespaceIndexOfText = text.startsWith('\n') ? 1 : text.search(/\S/);
+					const firstNonWhitespaceIndexOfText = text.startsWith('\n') ? 0 : text.search(/\S/);
 
 					const offsetStart = offset + (firstNonWhitespaceIndexOfText > 0 ? firstNonWhitespaceIndexOfText : 0);
 

--- a/packages/unplugin-typia/src/core/index.ts
+++ b/packages/unplugin-typia/src/core/index.ts
@@ -88,8 +88,12 @@ const unpluginFactory: UnpluginFactory<
 				if (next != null && next[0] === 1) {
 					const replaceText = next[1];
 
-					/** get first non-whitespace character of text (maybe bug of magic-string) */
-					const firstNonWhitespaceIndexOfText = text.search(/\S/);
+					/**
+					 * get first non-whitespace character of text (maybe bug of magic-string)
+					 * text.search(/\S/) ignore `\n`, but it is important (https://github.com/ryoppippi/unplugin-typia/issues/434)
+					 */
+					const firstNonWhitespaceIndexOfText = text.startsWith('\n') ? 1 : text.search(/\S/);
+
 					const offsetStart = offset + (firstNonWhitespaceIndexOfText > 0 ? firstNonWhitespaceIndexOfText : 0);
 
 					s.update(offsetStart, offset + textLength, replaceText);


### PR DESCRIPTION
The fundamental issue is that Diff is not performing comparisons correctly, but even before that, there was an incorrect string replacement.
This PR addresses and fixes that problem.


related issue: https://github.com/ryoppippi/unplugin-typia/issues/434

fixes: #434 

---
This pull request addresses a bug in the `unplugin-typia` package related to whitespace handling in the `magic-string` library. The change ensures that newline characters (`\n`) are correctly accounted for when determining the first non-whitespace character in a text string.

Bug fix:

* [`packages/unplugin-typia/src/core/index.ts`](diffhunk://#diff-215496816818bb56195ecc1879e0ffdd910d57a2fc1d3b815062dc1d39b3c43aL91-R96): Updated the logic for calculating the `firstNonWhitespaceIndexOfText` to handle cases where the text starts with a newline (`\n`). This resolves an issue where `text.search(/\S/)` was ignoring newline characters, which are significant in the context of the `magic-string` library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of newline characters when determining the position of the first non-whitespace character in text segments, ensuring more accurate text replacement in diff processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->