### PR TITLE
feat(webpack): update docs for node20 

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -112,7 +112,6 @@
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",
         "ts-patch": "^3.3.0",
-        "tsx": "^4.19.4",
         "typescript": "~5.8.3",
         "webpack": "^5.98.0",
         "webpack-cli": "^6.0.1",

--- a/examples/webpack-minimal/package.json
+++ b/examples/webpack-minimal/package.json
@@ -9,7 +9,6 @@
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "ts-patch": "^3.3.0",
-    "tsx": "^4.19.4",
     "typescript": "~5.8.3",
     "webpack": "^5.98.0",
     "webpack-cli": "^6.0.1",

--- a/examples/webpack-minimal/webpack.config.ts
+++ b/examples/webpack-minimal/webpack.config.ts
@@ -4,12 +4,11 @@ import 'webpack-dev-server'
 import path from 'path';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import WorkboxWebpackPlugin from 'workbox-webpack-plugin';
-import * as tsx from 'tsx/cjs/api'
+import UnpluginTypia from '@ryoppippi/unplugin-typia/webpack';
 
 const __filename = import.meta.filename;
 const __dirname = import.meta.dirname;
 
-const {default: UnpluginTypia}  = tsx.require('../../packages/unplugin-typia/src/webpack.ts', __filename)
 
 const isProduction = process.env.NODE_ENV == 'production';
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "ryoppippi",
   "license": "MIT",
   "scripts": {
-    "build": "bun run --filter '*' build",
+    "build": "bun run --filter '@ryoppippi/*' build",
+    "postbuild": "bun run --filter '!@ryoppippi/*' build",
     "lint": "bun run --filter '*' lint",
     "format": "bun run --filter '*' format",
     "test": "bun run --filter '*' test",

--- a/packages/unplugin-typia/README.md
+++ b/packages/unplugin-typia/README.md
@@ -191,25 +191,10 @@ Examples:
 <details>
 <summary>Webpack</summary><br>
 
-> ⚠️ Note: Currently, this plugin works only with 'esm' target.
-
-> If you want to use 'cjs' target on Node < 20.17.0 , please use with [`jiti`](https://github.com/unjs/jiti).
-> If you want to use 'cjs' target on Node >= 20.17.0, please use with `require` and enable [`--experimental-require-modules` flag](https://github.com/nodejs/node/pull/51977).
-> If you want to use 'esm' target, don't worry! You can use this plugin without any additional setup.
-
-```sh
-npm install jiti
-```
-
 ```js
 // webpack.config.js
 
-// if you use Node < 20.17.0
-const jiti = require('jiti')(__filename);
-const { default: UnpluginTypia } = jiti('@ryoppippi/unplugin-typia/webpack');
-
-// if you use Node >= 20.17.0
-// const { default: UnpluginTypia } = require("@ryoppippi/unplugin-typia/webpack");
+const { default: UnpluginTypia } = require('@ryoppippi/unplugin-typia/webpack');
 
 module.exports = {
 	plugins: [

--- a/packages/unplugin-typia/src/webpack.ts
+++ b/packages/unplugin-typia/src/webpack.ts
@@ -9,23 +9,10 @@ import unplugin from './core/index.js';
 /**
  * Webpack plugin
  *
- * Currently, this plugin works only with 'esm' target.
- *
- * If you want to use 'cjs' target on Node < 20.17.0 , please use with [`jiti`](https://github.com/unjs/jiti).
- * If you want to use 'cjs' target on Node >= 20.17.0, please use with `require` and enable [`--experimental-require-modules` flag](https://github.com/nodejs/node/pull/51977).
- * If you want to use 'esm' target, don't worry! You can use this plugin without any additional setup.
- *
- * Refer this issue https://github.com/samchon/typia/issues/1094
- *
  * @example
  * ```js
  * // webpack.config.js
  *
- * // if you use Node < 20.17.0
- * const jiti = require("jiti")(__filename);
- * const { default: UnpluginTypia } = jiti("@ryoppippi/unplugin-typia/webpack");
- *
- * // if you use Node >= 20.17.0
  * const { default: UnpluginTypia } = require("@ryoppippi/unplugin-typia/webpack");
  *
  * module.exports = {


### PR DESCRIPTION
This pull request simplifies the usage of the `@ryoppippi/unplugin-typia` Webpack plugin by removing support for older Node.js configurations and dependencies like `jiti` and `tsx`. It also updates the documentation and example configurations accordingly.

### Simplification of Webpack Plugin Usage:

* Removed the dependency on `tsx` in `examples/webpack-minimal/package.json` as it is no longer required for the Webpack plugin. (`[examples/webpack-minimal/package.jsonL12](diffhunk://#diff-bff8244d7d4c82c3f65e1ff6214f70c59ad77f2e24d93a1a6655b9c138bb482aL12)`)
* Updated the `webpack.config.ts` file in `examples/webpack-minimal` to directly import `UnpluginTypia` from `@ryoppippi/unplugin-typia/webpack`, eliminating the need for `tsx.require`. (`[examples/webpack-minimal/webpack.config.tsL7-L12](diffhunk://#diff-0e0da6eaf89d2a649c25c4527e4d3561605ab19f57f5cd08e344a093516d8bb9L7-L12)`)

### Documentation Updates:

* Simplified the example code in `packages/unplugin-typia/README.md` by removing instructions for using `jiti` or the `--experimental-require-modules` flag. The plugin now supports a single, straightforward configuration. (`[packages/unplugin-typia/README.mdL194-R197](diffhunk://#diff-959112ddbb7cdbe1e34167c9522cf73ccfbce86955ac9560cfe1ae50a43fcac2L194-R197)`)
* Cleaned up comments and examples in `packages/unplugin-typia/src/webpack.ts` to reflect the removal of support for older Node.js configurations and to align with the updated usage pattern. (`[packages/unplugin-typia/src/webpack.tsL12-L28](diffhunk://#diff-720bf79f8c753ecde49f5cd45c06e8e2e707416a0a68682d0737987143cb1d72L12-L28)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified Webpack usage instructions in the documentation, removing conditional setup steps and presenting a unified import approach.
- **Chores**
  - Removed an unnecessary development dependency from the example project.
  - Updated example configuration to use a direct import for the Webpack plugin, streamlining setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->