### PR TITLE
test: use fs-fixture for creating tmp dir

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -147,6 +147,7 @@
         "esbuild": "^0.25.4",
         "eslint": "~9.23.0",
         "eslint-plugin-format": "^1.0.1",
+        "fs-fixture": "^2.7.1",
         "npm-run-all2": "^8.0.3",
         "publint": "^0.3.12",
         "rollup": "^4.36.0",
@@ -1601,6 +1602,8 @@
     "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
 
     "fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
+
+    "fs-fixture": ["fs-fixture@2.7.1", "", {}, "sha512-fh9PEM+vCFvO8zPztFRW0c8kcG67AfDZ1aMfMO9i2dKFd2WpeNtmZyTDjfmB7AyPRWDPo+NcBj5Ng2llTS7SFA=="],
 
     "fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
 

--- a/packages/unplugin-typia/package.json
+++ b/packages/unplugin-typia/package.json
@@ -120,6 +120,7 @@
 		"esbuild": "^0.25.4",
 		"eslint": "~9.23.0",
 		"eslint-plugin-format": "^1.0.1",
+		"fs-fixture": "^2.7.1",
 		"npm-run-all2": "^8.0.3",
 		"publint": "^0.3.12",
 		"rollup": "^4.36.0",

--- a/packages/unplugin-typia/src/core/cache.ts
+++ b/packages/unplugin-typia/src/core/cache.ts
@@ -1,8 +1,8 @@
 import { accessSync, constants, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import process from 'node:process';
 import { createHash } from 'node:crypto';
 import { createRequire } from 'node:module';
+import { createFixture } from 'fs-fixture';
 import { basename, dirname, join } from 'pathe';
 import findCacheDirectory from 'find-cache-dir';
 import type { CacheKey, CachePath, Data, FilePath, ID, Source } from './types.js';
@@ -131,7 +131,8 @@ function getCacheDir(): FilePath {
 }
 
 if (import.meta.vitest != null) {
-	process.env.CACHE_DIR = tmpdir();
+	await using fixture = await createFixture();
+	process.env.CACHE_DIR = fixture.path;
 
 	function removeComments(data: string | undefined) {
 		if (data == null) {


### PR DESCRIPTION
This pull request introduces a new dependency, `fs-fixture`, and integrates it into the `cache.ts` file to enhance testability by replacing the use of `tmpdir()` with dynamically created fixtures. Below are the most important changes grouped by theme.

### Dependency Addition:

* [`packages/unplugin-typia/package.json`](diffhunk://#diff-cddf85f2cd0f1df90dea84161c47eb60b072d7c7b688b6d680615b3a0c65a4eeR123): Added `fs-fixture` as a new dependency to support the creation of temporary file fixtures for testing.

### Code Enhancements for Testability:

* [`packages/unplugin-typia/src/core/cache.ts`](diffhunk://#diff-2498f43e710738e5e015c1027a02b6b49fcc83f0f3f3bb935dba3c92ccbd77c2L2-R5): Imported `createFixture` from `fs-fixture` and removed the import of `tmpdir` from `node:os`.
* [`packages/unplugin-typia/src/core/cache.ts`](diffhunk://#diff-2498f43e710738e5e015c1027a02b6b49fcc83f0f3f3bb935dba3c92ccbd77c2L134-R135): Updated the `getCacheDir` function to use `createFixture` for creating temporary file fixtures during tests, replacing the previous approach using `tmpdir()`. This improves the isolation and reliability of test environments.